### PR TITLE
#5535 - Décorréler la récupération d'entreprise de la période de changements administratifs (mise à jour des entreprises via l'Insee)

### DIFF
--- a/back/src/config/bootstrap/appConfig.ts
+++ b/back/src/config/bootstrap/appConfig.ts
@@ -126,6 +126,7 @@ export class AppConfig {
   public get brevoEstablishmentContactListId(): number {
     return Number.parseInt(
       this.#throwIfNotDefinedOrDefault("BREVO_ESTABLISHMENT_CONTACT_LIST_ID"),
+      10,
     );
   }
 
@@ -263,6 +264,7 @@ export class AppConfig {
   public get externalAxiosTimeout(): number {
     return Number.parseInt(
       this.#throwIfNotDefinedOrDefault("EXTERNAL_AXIOS_TIMEOUT", "10000"),
+      10,
     );
   }
 
@@ -272,6 +274,7 @@ export class AppConfig {
         "EXTERNAL_AXIOS_TIMEOUT_FOR_FRANCE_TRAVAIL",
         "10000",
       ),
+      10,
     );
   }
 
@@ -404,6 +407,7 @@ export class AppConfig {
   public get maxConventionsToSyncWithPe() {
     return Number.parseInt(
       this.#throwIfNotDefinedOrDefault("MAX_CONVENTIONS_TO_SYNC_WITH_PE", "50"),
+      10,
     );
   }
 
@@ -432,6 +436,7 @@ export class AppConfig {
         "MINIMUM_NUMBER_OF_DAYS_BETWEEN_SIMILAR_CONTACT_REQUESTS",
         "7",
       ),
+      10,
     );
   }
 
@@ -445,6 +450,7 @@ export class AppConfig {
   public get nodeProcessReportInterval(): number {
     return Number.parseInt(
       this.#throwIfNotDefinedOrDefault("NODE_PROCESS_REPORT_INTERVAL", "30000"),
+      10,
     );
   }
 
@@ -515,6 +521,7 @@ export class AppConfig {
   public get pgTransactionIdleTimeoutMs() {
     return Number.parseInt(
       this.#throwIfNotDefinedOrDefault("PG_TRANSACTION_IDLE_TIMEOUT_MS", "0"),
+      10,
     );
   }
 
@@ -639,24 +646,28 @@ export class AppConfig {
           "MAX_ESTABLISHMENTS_PER_BATCH",
           "1000",
         ),
+        10,
       ),
       maxEstablishmentsPerFullRun: Number.parseInt(
         this.#throwIfNotDefinedOrDefault(
           "MAX_ESTABLISHMENTS_PER_FULL_RUN",
           "5000",
         ),
+        10,
       ),
       numberOfDaysAgoToCheckForInseeUpdates: Number.parseInt(
         this.#throwIfNotDefinedOrDefault(
           "NUMBER_OF_DAYS_AGO_TO_CHECK_FOR_INSEE_UPDATES",
           "30",
         ),
+        10,
       ),
       numberOfDaysToRetrieveInseeUpdates: Number.parseInt(
         this.#throwIfNotDefinedOrDefault(
           "NUMBER_OF_DAYS_TO_RETRIEVE_INSEE_UPDATES",
           "120",
         ),
+        10,
       ),
     };
   }
@@ -672,7 +683,7 @@ export class AppConfig {
 // Parsers
 
 const parseInteger = (str: string | undefined, defaultValue: number): number =>
-  str ? Number.parseInt(str) : defaultValue;
+  str ? Number.parseInt(str, 10) : defaultValue;
 
 const parseOptionalPositiveInteger = (
   str: string | undefined,

--- a/back/src/config/bootstrap/appConfig.ts
+++ b/back/src/config/bootstrap/appConfig.ts
@@ -652,6 +652,12 @@ export class AppConfig {
           "30",
         ),
       ),
+      numberOfDaysToRetrieveInseeUpdates: Number.parseInt(
+        this.#throwIfNotDefinedOrDefault(
+          "NUMBER_OF_DAYS_TO_RETRIEVE_INSEE_UPDATES",
+          "120",
+        ),
+      ),
     };
   }
 

--- a/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.integration.test.ts
+++ b/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.integration.test.ts
@@ -3533,4 +3533,56 @@ describe("PgEstablishmentAggregateRepository", () => {
       );
     });
   });
+
+  describe("updateEstablishmentsWithInseeData", () => {
+    const siret = "91523634300017";
+    const inseeCheckDate = new Date("2026-08-25T10:00:00.000Z");
+
+    beforeEach(async () => {
+      await pgEstablishmentAggregateRepository.insertEstablishmentAggregate(
+        new EstablishmentAggregateBuilder()
+          .withEstablishment(
+            new EstablishmentEntityBuilder()
+              .withSiret(siret)
+              .withName("LE BASILIC")
+              .withIsOpen(true)
+              .withLastInseeCheck(subDays(inseeCheckDate, 31))
+              .build(),
+          )
+          .withUserRights([osefUserRight])
+          .build(),
+      );
+    });
+
+    it("updates is_open to false when insee returns a closed establishment", async () => {
+      await pgEstablishmentAggregateRepository.updateEstablishmentsWithInseeData(
+        inseeCheckDate,
+        {
+          [siret]: {
+            isOpen: false,
+            name: "LE BASILIC",
+            nafDto: { code: "4761Z", nomenclature: "NAFRev2" },
+            numberEmployeesRange: "1-2",
+          },
+        },
+      );
+
+      const aggregate =
+        await pgEstablishmentAggregateRepository.getEstablishmentAggregateBySiret(
+          siret,
+        );
+
+      expectToEqual(aggregate?.establishment.isOpen, false);
+      expectToEqual(aggregate?.establishment.name, "LE BASILIC");
+      expectToEqual(aggregate?.establishment.nafDto, {
+        code: "4761Z",
+        nomenclature: "NAFRev2",
+      });
+      expectToEqual(aggregate?.establishment.numberEmployeesRange, "1-2");
+      expectToEqual(
+        aggregate?.establishment.lastInseeCheckDate,
+        inseeCheckDate,
+      );
+    });
+  });
 });

--- a/back/src/domains/establishment/use-cases/UpdateEstablishmentsFromSirenApiScript.ts
+++ b/back/src/domains/establishment/use-cases/UpdateEstablishmentsFromSirenApiScript.ts
@@ -33,6 +33,7 @@ type Deps = {
   siretGateway: SiretGateway;
   timeGateway: TimeGateway;
   numberOfDaysAgoToCheckForInseeUpdates: number;
+  numberOfDaysToRetrieveInseeUpdates: number;
   maxEstablishmentsPerBatch: number;
   maxEstablishmentsPerFullRun: number;
 };
@@ -46,7 +47,14 @@ export const makeUpdateEstablishmentsFromSirenApiScript = useCaseBuilder(
   .build(async ({ deps }) => {
     let callsToInseeApi = 0;
     const now = deps.timeGateway.now();
-    const since = subDays(now, deps.numberOfDaysAgoToCheckForInseeUpdates);
+    const sinceLastCheck = subDays(
+      now,
+      deps.numberOfDaysAgoToCheckForInseeUpdates,
+    );
+    const sinceInseeUpdates = subDays(
+      now,
+      deps.numberOfDaysToRetrieveInseeUpdates,
+    );
 
     let offset = 0;
     let numberOfEstablishmentsToUpdate = 0;
@@ -57,7 +65,7 @@ export const makeUpdateEstablishmentsFromSirenApiScript = useCaseBuilder(
         numberOfEstablishmentsToUpdateInBatch,
         establishmentWithNewDataInBatch,
         isInseeApiCalled: isCallToInseeApi,
-      } = await processOneBatch(deps, now, since);
+      } = await processOneBatch(deps, now, sinceLastCheck, sinceInseeUpdates);
 
       if (isCallToInseeApi) callsToInseeApi++;
 
@@ -83,12 +91,13 @@ export const makeUpdateEstablishmentsFromSirenApiScript = useCaseBuilder(
 const processOneBatch = async (
   deps: Deps,
   now: Date,
-  since: Date,
+  sinceLastCheck: Date,
+  sinceInseeUpdates: Date,
 ): Promise<BatchReport & { isInseeApiCalled: boolean }> => {
   const establishmentSiretsToUpdate: SiretDto[] =
     await deps.uowPerformer.perform(async (uow: UnitOfWork) =>
       uow.establishmentAggregateRepository.getSiretsOfEstablishmentsNotCheckedAtInseeSince(
-        since,
+        sinceLastCheck,
         deps.maxEstablishmentsPerBatch,
       ),
     );
@@ -109,7 +118,7 @@ const processOneBatch = async (
   const siretEstablishmentsWithChanges =
     establishmentSiretsToUpdate.length > 0
       ? await deps.siretGateway.getEstablishmentUpdatedBetween(
-          since,
+          sinceInseeUpdates,
           now,
           establishmentSiretsToUpdate,
         )

--- a/back/src/domains/establishment/use-cases/UpdateEstablishmentsFromSireneApiScript.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/UpdateEstablishmentsFromSireneApiScript.unit.test.ts
@@ -22,6 +22,7 @@ import {
 const maxEstablishmentsPerBatch = 1;
 const maxEstablishmentsPerFullRun = 2;
 const numberOfDaysAgoToCheckForInseeUpdates = 30;
+const numberOfDaysToRetrieveInseeUpdates = 120;
 const now = new Date("2023-06-16");
 
 describe("Update establishments from Sirene API", () => {
@@ -42,6 +43,7 @@ describe("Update establishments from Sirene API", () => {
         timeGateway,
         uowPerformer,
         numberOfDaysAgoToCheckForInseeUpdates,
+        numberOfDaysToRetrieveInseeUpdates,
         maxEstablishmentsPerBatch,
         maxEstablishmentsPerFullRun,
       },


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
