### PR TITLE
#5399 - Typage du formulaire du bilan plus safe

### DIFF
--- a/front/src/app/components/forms/assessment/AssessmentForm.tsx
+++ b/front/src/app/components/forms/assessment/AssessmentForm.tsx
@@ -222,6 +222,38 @@ const AssessmentStatusSection = ({
 
   const getFieldError = makeFieldError(formState);
 
+  const setEstablishmentComments = (comments: string): void => {
+    setValue("establishmentAdvices", comments);
+    setValue("establishmentFeedback", comments);
+  };
+
+  const onStatusChange = (value: string): void => {
+    const status = match(value)
+      .with("COMPLETED", (matched) => {
+        unregister("partialCompletionDetails");
+        setEstablishmentComments("");
+        return matched;
+      })
+      .with("PARTIALLY_COMPLETED", (matched) => {
+        setEstablishmentComments("");
+        setValue("partialCompletionDetails", {
+          lastDayOfPresence: null,
+          numberOfMissedHours: null,
+          numberOfMissedMinutes: null,
+        });
+        return matched;
+      })
+      .with("DID_NOT_SHOW", (matched) => {
+        setEstablishmentComments("Non applicable");
+        setValue("endedWithAJob", false);
+        unregister("partialCompletionDetails");
+        return matched;
+      })
+      .otherwise(() => null);
+
+    if (status) setValue("status", status);
+  };
+
   const formValues = watch();
 
   const partialCompletionDetailsFormValue =
@@ -268,33 +300,7 @@ const AssessmentStatusSection = ({
               nativeInputProps: {
                 value,
                 ...register("status"),
-                onChange: (event) => {
-                  const { value } = event.target;
-                  if (value === "COMPLETED") {
-                    unregister("partialCompletionDetails");
-                  }
-                  if (
-                    value === "PARTIALLY_COMPLETED" ||
-                    value === "COMPLETED"
-                  ) {
-                    setValue("establishmentAdvices", "");
-                    setValue("establishmentFeedback", "");
-                  }
-                  if (value === "DID_NOT_SHOW") {
-                    setValue("establishmentAdvices", "Non applicable");
-                    setValue("establishmentFeedback", "Non applicable");
-                    setValue("endedWithAJob", false);
-                    unregister("partialCompletionDetails");
-                  }
-                  if (value === "PARTIALLY_COMPLETED") {
-                    setValue("partialCompletionDetails", {
-                      lastDayOfPresence: null,
-                      numberOfMissedHours: null,
-                      numberOfMissedMinutes: null,
-                    });
-                  }
-                  setValue("status", value as AssessmentStatus);
-                },
+                onChange: (event) => onStatusChange(event.target.value),
               },
             }))}
             {...getFieldError("status")}

--- a/front/src/app/components/forms/assessment/AssessmentForm.tsx
+++ b/front/src/app/components/forms/assessment/AssessmentForm.tsx
@@ -52,23 +52,22 @@ type AssessmentFormProperties = {
   onAssessmentSubmitted: (assessment: AssessmentDto) => void;
 };
 
+type Step = 1 | 2 | 3;
+
+type AssessmentFormFieldPath =
+  | keyof AssessmentFormDto
+  | DotNestedKeys<AssessmentFormDto>;
+
 export type OnStepChange = (
   step: Step,
-  fieldsToValidate: (
-    | keyof AssessmentFormDto
-    | DotNestedKeys<AssessmentFormDto>
-  )[],
+  fieldsToValidate: AssessmentFormFieldPath[],
 ) => void;
-
-type Step = 1 | 2 | 3;
 
 const partialCompletionDetailsFields = [
   "partialCompletionDetails",
   "partialCompletionDetails.lastDayOfPresence",
   "partialCompletionDetails.numberOfMissedHours",
-] as const satisfies ReadonlyArray<
-  keyof AssessmentFormDto | DotNestedKeys<AssessmentFormDto>
->;
+] as const satisfies ReadonlyArray<AssessmentFormFieldPath>;
 
 const steps: Record<Step, Pick<StepperProps, "title" | "nextTitle">> = {
   1: {
@@ -95,11 +94,6 @@ export const AssessmentForm = ({
   const initialValues: AssessmentFormDto = {
     conventionId: convention.id,
     status: null,
-    partialCompletionDetails: {
-      lastDayOfPresence: null,
-      numberOfMissedHours: null,
-      numberOfMissedMinutes: null,
-    },
     endedWithAJob: null,
     typeOfContract: null,
     contractStartDate: null,
@@ -223,17 +217,20 @@ const AssessmentStatusSection = ({
   convention: ConventionDto;
   onStepChange: OnStepChange;
 }) => {
-  const { register, formState, watch, setValue } =
+  const { register, formState, watch, setValue, unregister } =
     useFormContext<AssessmentFormDto>();
 
   const getFieldError = makeFieldError(formState);
 
   const formValues = watch();
 
-  const partialCompletionDetailsFormValue = formValues.partialCompletionDetails;
+  const partialCompletionDetailsFormValue =
+    formValues.status === "PARTIALLY_COMPLETED"
+      ? formValues.partialCompletionDetails
+      : null;
 
   const hasImmersionEndedEarly =
-    partialCompletionDetailsFormValue.lastDayOfPresence &&
+    partialCompletionDetailsFormValue?.lastDayOfPresence &&
     new Date(partialCompletionDetailsFormValue.lastDayOfPresence) <
       new Date(convention.dateEnd);
 
@@ -273,6 +270,9 @@ const AssessmentStatusSection = ({
                 ...register("status"),
                 onChange: (event) => {
                   const { value } = event.target;
+                  if (value === "COMPLETED") {
+                    unregister("partialCompletionDetails");
+                  }
                   if (
                     value === "PARTIALLY_COMPLETED" ||
                     value === "COMPLETED"
@@ -284,6 +284,14 @@ const AssessmentStatusSection = ({
                     setValue("establishmentAdvices", "Non applicable");
                     setValue("establishmentFeedback", "Non applicable");
                     setValue("endedWithAJob", false);
+                    unregister("partialCompletionDetails");
+                  }
+                  if (value === "PARTIALLY_COMPLETED") {
+                    setValue("partialCompletionDetails", {
+                      lastDayOfPresence: null,
+                      numberOfMissedHours: null,
+                      numberOfMissedMinutes: null,
+                    });
                   }
                   setValue("status", value as AssessmentStatus);
                 },

--- a/shared/src/assessment/assessment.dto.ts
+++ b/shared/src/assessment/assessment.dto.ts
@@ -33,7 +33,7 @@ export type WithEstablishmentComments = {
   establishmentAdvices: string;
 };
 
-type CommonAssessmentFields = {
+export type CommonAssessmentFields = {
   conventionId: ConventionId;
   beneficiaryAgreement: boolean | null;
   beneficiaryFeedback: string | null;
@@ -100,11 +100,32 @@ export type PartiallyCompletedAssessmentDetails = {
   numberOfMissedMinutes: number | null;
 };
 
-export type AssessmentFormDto = {
+export type AssessmentFormCommonFields = {
   conventionId: ConventionId;
-  status: AssessmentStatus | null;
-  partialCompletionDetails: PartiallyCompletedAssessmentDetails;
   endedWithAJob: boolean | null;
   typeOfContract: TypeOfContract | null;
   contractStartDate: DateString | null;
 } & WithEstablishmentComments;
+
+export type AssessmentFormDtoWithStatusNull = AssessmentFormCommonFields & {
+  status: null;
+};
+
+export type AssessmentFormDtoCompleted = AssessmentFormCommonFields & {
+  status: "COMPLETED";
+};
+
+export type AssessmentFormDtoDidNotShow = AssessmentFormCommonFields & {
+  status: "DID_NOT_SHOW";
+};
+
+export type AssessmentFormDtoPartiallyCompleted = AssessmentFormCommonFields & {
+  status: "PARTIALLY_COMPLETED";
+  partialCompletionDetails: PartiallyCompletedAssessmentDetails;
+};
+
+export type AssessmentFormDto =
+  | AssessmentFormDtoWithStatusNull
+  | AssessmentFormDtoCompleted
+  | AssessmentFormDtoDidNotShow
+  | AssessmentFormDtoPartiallyCompleted;

--- a/shared/src/assessment/assessment.helpers.unit.test.ts
+++ b/shared/src/assessment/assessment.helpers.unit.test.ts
@@ -16,7 +16,7 @@ describe("assessment helpers", () => {
 
   const createdAt = "2024-01-21T00:00:00.000Z";
 
-  const baseFormValues: AssessmentFormDto = {
+  const basePartiallyCompletedFormValues: AssessmentFormDto = {
     conventionId: convention.id,
     status: "PARTIALLY_COMPLETED",
     partialCompletionDetails: {
@@ -24,6 +24,16 @@ describe("assessment helpers", () => {
       numberOfMissedHours: null,
       numberOfMissedMinutes: null,
     },
+    endedWithAJob: false,
+    typeOfContract: null,
+    contractStartDate: null,
+    establishmentFeedback: "feedback",
+    establishmentAdvices: "advices",
+  };
+
+  const baseCompletedFormValues: AssessmentFormDto = {
+    conventionId: convention.id,
+    status: "COMPLETED",
     endedWithAJob: false,
     typeOfContract: null,
     contractStartDate: null,
@@ -109,9 +119,9 @@ describe("assessment helpers", () => {
     it("maps hours-only form to PARTIALLY_COMPLETED with convention.dateEnd", () => {
       const assessment = assessmentFormValuesToAssessmentDto(
         {
-          ...baseFormValues,
+          ...basePartiallyCompletedFormValues,
           partialCompletionDetails: {
-            ...baseFormValues.partialCompletionDetails,
+            ...basePartiallyCompletedFormValues.partialCompletionDetails,
             numberOfMissedHours: 2,
           },
         },
@@ -137,7 +147,7 @@ describe("assessment helpers", () => {
     it("maps date-only form (0h 0min) to PARTIALLY_COMPLETED with numberOfMissedHours 0", () => {
       const assessment = assessmentFormValuesToAssessmentDto(
         {
-          ...baseFormValues,
+          ...basePartiallyCompletedFormValues,
           partialCompletionDetails: {
             lastDayOfPresence: "2024-01-18",
             numberOfMissedHours: 0,
@@ -166,7 +176,7 @@ describe("assessment helpers", () => {
     it("maps 1h30 to numberOfMissedHours 1.5", () => {
       const assessment = assessmentFormValuesToAssessmentDto(
         {
-          ...baseFormValues,
+          ...basePartiallyCompletedFormValues,
           partialCompletionDetails: {
             lastDayOfPresence: "2024-01-18",
             numberOfMissedHours: 1,
@@ -184,10 +194,7 @@ describe("assessment helpers", () => {
 
     it("maps COMPLETED status", () => {
       const assessment = assessmentFormValuesToAssessmentDto(
-        {
-          ...baseFormValues,
-          status: "COMPLETED",
-        },
+        baseCompletedFormValues,
         convention,
         createdAt,
       );
@@ -208,8 +215,7 @@ describe("assessment helpers", () => {
     it("maps endedWithAJob when contract fields are filled", () => {
       const assessment = assessmentFormValuesToAssessmentDto(
         {
-          ...baseFormValues,
-          status: "COMPLETED",
+          ...baseCompletedFormValues,
           endedWithAJob: true,
           typeOfContract: "CDI",
           contractStartDate: "2024-01-15",
@@ -237,9 +243,9 @@ describe("assessment helpers", () => {
   describe("computeTotalHours via mapper", () => {
     it("gives the same total for hours-only form as with lastDayOfPresence = convention.dateEnd", () => {
       const formValues: AssessmentFormDto = {
-        ...baseFormValues,
+        ...basePartiallyCompletedFormValues,
         partialCompletionDetails: {
-          ...baseFormValues.partialCompletionDetails,
+          ...basePartiallyCompletedFormValues.partialCompletionDetails,
           numberOfMissedHours: 2,
         },
       };

--- a/shared/src/assessment/assessment.schema.ts
+++ b/shared/src/assessment/assessment.schema.ts
@@ -104,24 +104,40 @@ const partialCompletionDetailsFormValuesSchema: ZodSchemaWithInputMatchingOutput
     numberOfMissedMinutes: z.number().nullable(),
   });
 
-const assessmentFormValuesBaseSchema: ZodSchemaWithInputMatchingOutput<AssessmentFormDto> =
+const assessmentFormStatusSchema = z.discriminatedUnion("status", [
   z.object({
-    conventionId: z.string(),
-    status: z
-      .enum(["COMPLETED", "PARTIALLY_COMPLETED", "DID_NOT_SHOW"], {
-        error: localization.invalidEnum,
-      })
-      .nullable(),
+    status: z.literal("COMPLETED"),
+  }),
+  z.object({
+    status: z.literal("DID_NOT_SHOW"),
+  }),
+  z.object({
+    status: z.literal("PARTIALLY_COMPLETED"),
     partialCompletionDetails: partialCompletionDetailsFormValuesSchema,
-    endedWithAJob: z.boolean().nullable(),
-    typeOfContract: zEnumValidation(
-      typeOfContracts,
-      localization.required,
-    ).nullable(),
-    contractStartDate: makeDateStringSchema().nullable(),
-    establishmentFeedback: zStringMinLength1Max9200,
-    establishmentAdvices: zStringMinLength1Max6000,
-  });
+  }),
+]);
+
+const assessmentFormValuesBaseSchema: ZodSchemaWithInputMatchingOutput<AssessmentFormDto> =
+  z
+    .object({
+      conventionId: z.string(),
+      endedWithAJob: z.boolean().nullable(),
+      typeOfContract: zEnumValidation(
+        typeOfContracts,
+        localization.required,
+      ).nullable(),
+      contractStartDate: makeDateStringSchema().nullable(),
+      establishmentFeedback: zStringMinLength1Max9200,
+      establishmentAdvices: zStringMinLength1Max6000,
+    })
+    .and(
+      z.union([
+        z.object({
+          status: z.null(),
+        }),
+        assessmentFormStatusSchema,
+      ]),
+    );
 
 const toFormMissedHours = ({
   numberOfMissedHours,

--- a/shared/src/utils.ts
+++ b/shared/src/utils.ts
@@ -150,9 +150,9 @@ export type DotNestedKeys<T> = (
       : T extends Array<infer U>
         ? `${number}${DotPrefix<DotNestedKeys<U>>}`
         : {
-            [K in Exclude<keyof T, symbol>]: `${K}${DotPrefix<
-              DotNestedKeys<T[K]>
-            >}`;
+            [K in Exclude<keyof T, symbol>]:
+              | K
+              | `${K}${DotPrefix<DotNestedKeys<T[K]>>}`;
           }[Exclude<keyof T, symbol>]
     : ""
 ) extends infer D


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
