### PR TITLE
#5644 - Aligner l’affichage de l’erreur de synchro en page de pilotage avec la liste « Conventions à vérifier »

### DIFF
--- a/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.ts
+++ b/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.ts
@@ -44,15 +44,15 @@ export const makeGetLastBroadcastFeedback = useCaseBuilder(
         await uow.broadcastFeedbacksRepository.getBroadcastFeedbacksByConventionId(
           inputParams,
         );
-      const lastBroadcastFeedback = broadcastFeedbacks.at(-1);
+      const broadcastFeedback = broadcastFeedbacks.at(-1);
 
-      if (!lastBroadcastFeedback) return { lastBroadcastFeedback: null };
+      if (!broadcastFeedback) return { broadcastFeedback: null };
 
       return {
-        lastBroadcastFeedback,
+        broadcastFeedback,
         shouldBeHandled: shouldBroadcastFeedbackBeHandled(
           convention,
-          lastBroadcastFeedback,
+          broadcastFeedback,
           broadcastFeedbacks,
         ),
       };
@@ -64,12 +64,12 @@ export const makeGetLastBroadcastFeedback = useCaseBuilder(
 
 const shouldBroadcastFeedbackBeHandled = (
   convention: ConventionDto,
-  lastBroadcastFeedback: BroadcastFeedback,
+  broadcastFeedback: BroadcastFeedback,
   allBroadcastFeedbacks: BroadcastFeedback[],
 ): boolean => {
   if (
-    !lastBroadcastFeedback.subscriberErrorFeedback ||
-    lastBroadcastFeedback.handledByAgency
+    !broadcastFeedback.subscriberErrorFeedback ||
+    broadcastFeedback.handledByAgency
   )
     return false;
 

--- a/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.ts
+++ b/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.ts
@@ -32,10 +32,16 @@ export const makeGetLastBroadcastFeedback = useCaseBuilder(
       userHasEnoughRightsOnConvention(userWithRights, convention, [
         ...allAgencyRoles,
       ])
-    )
-      return uow.broadcastFeedbacksRepository.getLastBroadcastFeedback(
-        inputParams,
-      );
+    ) {
+      const lastBroadcastFeedback =
+        await uow.broadcastFeedbacksRepository.getLastBroadcastFeedback(
+          inputParams,
+        );
+      if (!lastBroadcastFeedback) {
+        return { lastBroadcastFeedback: null };
+      }
+      return { lastBroadcastFeedback, shouldBeHandled: false };
+    }
     throw errors.user.forbidden({
       userId: currentUser.id,
     });

--- a/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.ts
+++ b/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.ts
@@ -1,13 +1,20 @@
 import {
   allAgencyRoles,
+  type BroadcastFeedback,
   type ConnectedUser,
+  type ConventionDto,
   type ConventionId,
   type ConventionLastBroadcastFeedbackResponse,
   conventionIdSchema,
   errors,
+  isUnvalidatedConventionStatus,
   userHasEnoughRightsOnConvention,
 } from "shared";
 import { getUserWithRights } from "../../connected-users/helpers/userRights.helper";
+import {
+  broadcastToFtConsumerName,
+  broadcastToPartnersServiceName,
+} from "../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 
 export type GetLastBroadcastFeedback = ReturnType<
@@ -33,16 +40,55 @@ export const makeGetLastBroadcastFeedback = useCaseBuilder(
         ...allAgencyRoles,
       ])
     ) {
-      const lastBroadcastFeedback =
-        await uow.broadcastFeedbacksRepository.getLastBroadcastFeedback(
+      const broadcastFeedbacks =
+        await uow.broadcastFeedbacksRepository.getBroadcastFeedbacksByConventionId(
           inputParams,
         );
-      if (!lastBroadcastFeedback) {
-        return { lastBroadcastFeedback: null };
-      }
-      return { lastBroadcastFeedback, shouldBeHandled: false };
+      const lastBroadcastFeedback = broadcastFeedbacks.at(-1);
+
+      if (!lastBroadcastFeedback) return { lastBroadcastFeedback: null };
+
+      return {
+        lastBroadcastFeedback,
+        shouldBeHandled: shouldBroadcastFeedbackBeHandled(
+          convention,
+          lastBroadcastFeedback,
+          broadcastFeedbacks,
+        ),
+      };
     }
     throw errors.user.forbidden({
       userId: currentUser.id,
     });
   });
+
+const shouldBroadcastFeedbackBeHandled = (
+  convention: ConventionDto,
+  lastBroadcastFeedback: BroadcastFeedback,
+  allBroadcastFeedbacks: BroadcastFeedback[],
+): boolean => {
+  if (
+    !lastBroadcastFeedback.subscriberErrorFeedback ||
+    lastBroadcastFeedback.handledByAgency
+  )
+    return false;
+
+  if (new Date(convention.dateSubmission) < new Date("2025-01-01"))
+    return false;
+
+  if (isUnvalidatedConventionStatus(convention.status))
+    return hasPriorSuccessfulBroadcast(allBroadcastFeedbacks);
+
+  return true;
+};
+
+const hasPriorSuccessfulBroadcast = (
+  broadcastFeedbacks: BroadcastFeedback[],
+): boolean =>
+  broadcastFeedbacks.some(
+    (broadcastFeedback) =>
+      (broadcastFeedback.consumerName === broadcastToFtConsumerName &&
+        broadcastFeedback.response?.httpStatus === 201) ||
+      (broadcastFeedback.serviceName === broadcastToPartnersServiceName &&
+        !broadcastFeedback.subscriberErrorFeedback),
+  );

--- a/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
@@ -10,6 +10,11 @@ import {
 } from "shared";
 import { toAgencyWithRights } from "../../../utils/agency";
 import {
+  broadcastToFtConsumerName,
+  broadcastToFtServiceName,
+  broadcastToPartnersServiceName,
+} from "../../core/saved-errors/ports/BroadcastFeedbacksRepository";
+import {
   createInMemoryUow,
   type InMemoryUnitOfWork,
 } from "../../core/unit-of-work/adapters/createInMemoryUow";
@@ -21,8 +26,15 @@ import {
 
 describe("GetLastBroadcastFeedback", () => {
   const connectedUser = new ConnectedUserBuilder().build();
+  const backofficeAdmin = new ConnectedUserBuilder()
+    .withId("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    .withIsAdmin(true)
+    .build();
 
-  const convention = new ConventionDtoBuilder().build();
+  const convention = new ConventionDtoBuilder()
+    .withStatus("ACCEPTED_BY_VALIDATOR")
+    .withDateSubmission("2025-01-02T00:00:00.000Z")
+    .build();
 
   const agency = new AgencyDtoBuilder().withId(convention.agencyId).build();
 
@@ -44,8 +56,14 @@ describe("GetLastBroadcastFeedback", () => {
       httpStatus: 200,
       body: { success: true },
     },
-    occurredAt: "2024-01-16T10:00:00.000Z",
+    occurredAt: "2025-01-16T10:00:00.000Z",
     handledByAgency: true,
+  };
+
+  const unhandledErrorFeedback: BroadcastFeedback = {
+    ...sampleBroadcastFeedback,
+    handledByAgency: false,
+    occurredAt: "2025-01-16T10:00:00.000Z",
   };
 
   let getLastBroadcastFeedback: GetLastBroadcastFeedback;
@@ -60,7 +78,7 @@ describe("GetLastBroadcastFeedback", () => {
 
   describe("right paths", () => {
     beforeEach(async () => {
-      uow.userRepository.users = [connectedUser];
+      uow.userRepository.users = [connectedUser, backofficeAdmin];
       uow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [connectedUser.id]: { isNotifiedByEmail: true, roles: ["validator"] },
@@ -118,13 +136,13 @@ describe("GetLastBroadcastFeedback", () => {
     it("should return the most recent broadcast feedback when multiple exist", async () => {
       const olderFeedback: BroadcastFeedback = {
         ...sampleBroadcastFeedback,
-        occurredAt: "2024-01-15T10:00:00.000Z",
+        occurredAt: "2025-01-15T10:00:00.000Z",
         serviceName: "older-service",
       };
 
       const newerFeedback: BroadcastFeedback = {
         ...sampleBroadcastFeedback,
-        occurredAt: "2024-01-17T10:00:00.000Z",
+        occurredAt: "2025-01-17T10:00:00.000Z",
         serviceName: "newer-service",
       };
 
@@ -144,30 +162,18 @@ describe("GetLastBroadcastFeedback", () => {
       });
     });
 
-    it("should handle broadcast feedback with error response", async () => {
-      const errorFeedback: BroadcastFeedback = {
-        serviceName: "error-service",
-        consumerId: "error-consumer",
-        consumerName: "Error Consumer",
-        conventionId: convention.id,
-        agencyId: agency.id,
-        subscriberErrorFeedback: {
-          message: "Connection timeout",
-          error: { timeout: 5000 },
-        },
-        requestParams: {
-          conventionId: convention.id,
-          conventionStatus: "ACCEPTED_BY_VALIDATOR",
-        },
-        response: {
-          httpStatus: 500,
-          body: { error: "Internal server error" },
-        },
-        occurredAt: new Date("2024-01-16T10:00:00.000Z").toISOString(),
+    it("should return shouldBeHandled false when last feedback is a success", async () => {
+      const successFeedback: BroadcastFeedback = {
+        ...sampleBroadcastFeedback,
+        subscriberErrorFeedback: undefined,
         handledByAgency: false,
+        response: {
+          httpStatus: 201,
+          body: { success: true },
+        },
       };
 
-      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [errorFeedback];
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [successFeedback];
 
       const result = await getLastBroadcastFeedback.execute(
         convention.id,
@@ -175,8 +181,217 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: errorFeedback,
+        lastBroadcastFeedback: successFeedback,
         shouldBeHandled: false,
+      });
+    });
+
+    it("should return shouldBeHandled true for unhandled error on validated convention when submission is on or after 2025-01-01", async () => {
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        unhandledErrorFeedback,
+      ];
+
+      const result = await getLastBroadcastFeedback.execute(
+        convention.id,
+        connectedUser,
+      );
+
+      expectToEqual(result, {
+        lastBroadcastFeedback: unhandledErrorFeedback,
+        shouldBeHandled: true,
+      });
+    });
+
+    it("should return shouldBeHandled false when error is already handled", async () => {
+      const handledErrorFeedback: BroadcastFeedback = {
+        ...unhandledErrorFeedback,
+        handledByAgency: true,
+      };
+
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        handledErrorFeedback,
+      ];
+
+      const result = await getLastBroadcastFeedback.execute(
+        convention.id,
+        connectedUser,
+      );
+
+      expectToEqual(result, {
+        lastBroadcastFeedback: handledErrorFeedback,
+        shouldBeHandled: false,
+      });
+    });
+
+    it("should return shouldBeHandled false when submission is before 2025-01-01", async () => {
+      const conventionSubmittedBefore2025 = new ConventionDtoBuilder(convention)
+        .withDateSubmission("2024-12-31T23:59:59.000Z")
+        .build();
+      uow.conventionRepository.setConventions([conventionSubmittedBefore2025]);
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        unhandledErrorFeedback,
+      ];
+
+      const result = await getLastBroadcastFeedback.execute(
+        convention.id,
+        connectedUser,
+      );
+
+      expectToEqual(result, {
+        lastBroadcastFeedback: unhandledErrorFeedback,
+        shouldBeHandled: false,
+      });
+    });
+  });
+
+  describe("shouldBeHandled for unvalidated convention status", () => {
+    const cancelledConvention = new ConventionDtoBuilder(convention)
+      .withStatus("CANCELLED")
+      .withDateSubmission("2025-01-02T00:00:00.000Z")
+      .build();
+
+    const cancelledErrorFeedback: BroadcastFeedback = {
+      ...unhandledErrorFeedback,
+      requestParams: {
+        conventionId: convention.id,
+        conventionStatus: "CANCELLED",
+      },
+      serviceName: broadcastToFtServiceName,
+      occurredAt: "2025-01-16T14:00:00.000Z",
+    };
+
+    beforeEach(() => {
+      uow.userRepository.users = [connectedUser];
+      uow.agencyRepository.agencies = [
+        toAgencyWithRights(agency, {
+          [connectedUser.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+        }),
+      ];
+      uow.conventionRepository.setConventions([cancelledConvention]);
+    });
+
+    it("should return shouldBeHandled false for CANCELLED without prior success", async () => {
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        cancelledErrorFeedback,
+      ];
+
+      const result = await getLastBroadcastFeedback.execute(
+        convention.id,
+        connectedUser,
+      );
+
+      expectToEqual(result, {
+        lastBroadcastFeedback: cancelledErrorFeedback,
+        shouldBeHandled: false,
+      });
+    });
+
+    it("should return shouldBeHandled true for CANCELLED with prior FT httpStatus 201", async () => {
+      const priorFtSuccess: BroadcastFeedback = {
+        consumerId: null,
+        consumerName: broadcastToFtConsumerName,
+        conventionId: convention.id,
+        agencyId: agency.id,
+        serviceName: broadcastToFtServiceName,
+        occurredAt: "2025-01-16T08:00:00.000Z",
+        handledByAgency: false,
+        requestParams: {
+          conventionId: convention.id,
+          conventionStatus: "ACCEPTED_BY_VALIDATOR",
+        },
+        response: {
+          httpStatus: 201,
+        },
+      };
+
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        priorFtSuccess,
+        cancelledErrorFeedback,
+      ];
+
+      const result = await getLastBroadcastFeedback.execute(
+        convention.id,
+        connectedUser,
+      );
+
+      expectToEqual(result, {
+        lastBroadcastFeedback: cancelledErrorFeedback,
+        shouldBeHandled: true,
+      });
+    });
+
+    it("should return shouldBeHandled false for CANCELLED when prior FT has httpStatus 200 only", async () => {
+      const priorFtHttp200: BroadcastFeedback = {
+        consumerId: null,
+        consumerName: broadcastToFtConsumerName,
+        conventionId: convention.id,
+        agencyId: agency.id,
+        serviceName: broadcastToFtServiceName,
+        occurredAt: "2025-01-16T08:00:00.000Z",
+        handledByAgency: false,
+        requestParams: {
+          conventionId: convention.id,
+          conventionStatus: "ACCEPTED_BY_VALIDATOR",
+        },
+        response: {
+          httpStatus: 200,
+        },
+      };
+
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        priorFtHttp200,
+        cancelledErrorFeedback,
+      ];
+
+      const result = await getLastBroadcastFeedback.execute(
+        convention.id,
+        connectedUser,
+      );
+
+      expectToEqual(result, {
+        lastBroadcastFeedback: cancelledErrorFeedback,
+        shouldBeHandled: false,
+      });
+    });
+
+    it("should return shouldBeHandled true for CANCELLED with prior partner broadcast without error", async () => {
+      const partnerError: BroadcastFeedback = {
+        ...cancelledErrorFeedback,
+        consumerId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        consumerName: "partner-consumer",
+        serviceName: broadcastToPartnersServiceName,
+      };
+
+      const priorPartnerSuccess: BroadcastFeedback = {
+        consumerId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        consumerName: "partner-consumer",
+        conventionId: convention.id,
+        agencyId: agency.id,
+        serviceName: broadcastToPartnersServiceName,
+        occurredAt: "2025-01-16T08:00:00.000Z",
+        handledByAgency: false,
+        requestParams: {
+          conventionId: convention.id,
+          conventionStatus: "ACCEPTED_BY_VALIDATOR",
+        },
+        response: {
+          httpStatus: 200,
+        },
+      };
+
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        priorPartnerSuccess,
+        partnerError,
+      ];
+
+      const result = await getLastBroadcastFeedback.execute(
+        convention.id,
+        connectedUser,
+      );
+
+      expectToEqual(result, {
+        lastBroadcastFeedback: partnerError,
+        shouldBeHandled: true,
       });
     });
   });

--- a/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
@@ -1,9 +1,9 @@
 import {
   AgencyDtoBuilder,
   type BroadcastFeedback,
-  broadcastFeedbackSchema,
   ConnectedUserBuilder,
   ConventionDtoBuilder,
+  conventionLastBroadcastFeedbackResponseSchema,
   errors,
   expectPromiseToFailWithError,
   expectToEqual,
@@ -79,19 +79,27 @@ describe("GetLastBroadcastFeedback", () => {
         connectedUser,
       );
 
-      const parseResult = broadcastFeedbackSchema.safeParse(result);
+      const parseResult =
+        conventionLastBroadcastFeedbackResponseSchema.safeParse(result);
       expect(parseResult.success).toBeTruthy();
-      expectToEqual(result, sampleBroadcastFeedback);
+      expectToEqual(result, {
+        lastBroadcastFeedback: sampleBroadcastFeedback,
+        shouldBeHandled: false,
+      });
     });
 
     it("rejects broadcast feedbacks with inconsistent convention ids", () => {
-      const parseResult = broadcastFeedbackSchema.safeParse({
-        ...sampleBroadcastFeedback,
-        requestParams: {
-          ...sampleBroadcastFeedback.requestParams,
-          conventionId: "11111111-1111-4111-8111-111111111111",
-        },
-      });
+      const parseResult =
+        conventionLastBroadcastFeedbackResponseSchema.safeParse({
+          lastBroadcastFeedback: {
+            ...sampleBroadcastFeedback,
+            requestParams: {
+              ...sampleBroadcastFeedback.requestParams,
+              conventionId: "11111111-1111-4111-8111-111111111111",
+            },
+          },
+          shouldBeHandled: false,
+        });
 
       expect(parseResult.success).toBe(false);
     });
@@ -102,7 +110,9 @@ describe("GetLastBroadcastFeedback", () => {
         connectedUser,
       );
 
-      expectToEqual(result, null);
+      expectToEqual(result, {
+        lastBroadcastFeedback: null,
+      });
     });
 
     it("should return the most recent broadcast feedback when multiple exist", async () => {
@@ -128,7 +138,10 @@ describe("GetLastBroadcastFeedback", () => {
         connectedUser,
       );
 
-      expectToEqual(result, newerFeedback);
+      expectToEqual(result, {
+        lastBroadcastFeedback: newerFeedback,
+        shouldBeHandled: false,
+      });
     });
 
     it("should handle broadcast feedback with error response", async () => {
@@ -161,7 +174,10 @@ describe("GetLastBroadcastFeedback", () => {
         connectedUser,
       );
 
-      expectToEqual(result, errorFeedback);
+      expectToEqual(result, {
+        lastBroadcastFeedback: errorFeedback,
+        shouldBeHandled: false,
+      });
     });
   });
 

--- a/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
@@ -101,7 +101,7 @@ describe("GetLastBroadcastFeedback", () => {
         conventionLastBroadcastFeedbackResponseSchema.safeParse(result);
       expect(parseResult.success).toBeTruthy();
       expectToEqual(result, {
-        lastBroadcastFeedback: sampleBroadcastFeedback,
+        broadcastFeedback: sampleBroadcastFeedback,
         shouldBeHandled: false,
       });
     });
@@ -109,7 +109,7 @@ describe("GetLastBroadcastFeedback", () => {
     it("rejects broadcast feedbacks with inconsistent convention ids", () => {
       const parseResult =
         conventionLastBroadcastFeedbackResponseSchema.safeParse({
-          lastBroadcastFeedback: {
+          broadcastFeedback: {
             ...sampleBroadcastFeedback,
             requestParams: {
               ...sampleBroadcastFeedback.requestParams,
@@ -129,7 +129,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: null,
+        broadcastFeedback: null,
       });
     });
 
@@ -157,7 +157,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: newerFeedback,
+        broadcastFeedback: newerFeedback,
         shouldBeHandled: false,
       });
     });
@@ -181,7 +181,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: successFeedback,
+        broadcastFeedback: successFeedback,
         shouldBeHandled: false,
       });
     });
@@ -197,7 +197,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: unhandledErrorFeedback,
+        broadcastFeedback: unhandledErrorFeedback,
         shouldBeHandled: true,
       });
     });
@@ -218,7 +218,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: handledErrorFeedback,
+        broadcastFeedback: handledErrorFeedback,
         shouldBeHandled: false,
       });
     });
@@ -238,7 +238,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: unhandledErrorFeedback,
+        broadcastFeedback: unhandledErrorFeedback,
         shouldBeHandled: false,
       });
     });
@@ -281,7 +281,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: cancelledErrorFeedback,
+        broadcastFeedback: cancelledErrorFeedback,
         shouldBeHandled: false,
       });
     });
@@ -315,7 +315,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: cancelledErrorFeedback,
+        broadcastFeedback: cancelledErrorFeedback,
         shouldBeHandled: true,
       });
     });
@@ -349,7 +349,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: cancelledErrorFeedback,
+        broadcastFeedback: cancelledErrorFeedback,
         shouldBeHandled: false,
       });
     });
@@ -390,7 +390,7 @@ describe("GetLastBroadcastFeedback", () => {
       );
 
       expectToEqual(result, {
-        lastBroadcastFeedback: partnerError,
+        broadcastFeedback: partnerError,
         shouldBeHandled: true,
       });
     });

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastConventionAgain.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastConventionAgain.ts
@@ -6,8 +6,8 @@ import {
 } from "date-fns";
 import fr from "date-fns/locale/fr";
 import {
+  type BroadcastFeedback,
   type ConnectedUser,
-  type ConventionLastBroadcastFeedbackResponse,
   errors,
   userHasEnoughRightsOnConvention,
   type WithConventionId,
@@ -95,7 +95,7 @@ export const makeBroadcastConventionAgain = useCaseBuilder(
   });
 
 const throwErrorIfTooManyRequests = (params: {
-  lastBroadcastFeedback: ConventionLastBroadcastFeedbackResponse;
+  lastBroadcastFeedback: BroadcastFeedback | null;
   now: Date;
 }) => {
   if (!params.lastBroadcastFeedback) return;

--- a/back/src/domains/core/saved-errors/adapters/InMemoryBroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/InMemoryBroadcastFeedbacksRepository.ts
@@ -1,9 +1,4 @@
-import {
-  type BroadcastFeedback,
-  type ConventionId,
-  type ConventionLastBroadcastFeedbackResponse,
-  errors,
-} from "shared";
+import { type BroadcastFeedback, type ConventionId, errors } from "shared";
 
 import type { BroadcastFeedbacksRepository } from "../ports/BroadcastFeedbacksRepository";
 
@@ -56,7 +51,7 @@ export class InMemoryBroadcastFeedbacksRepository
 
   public async getLastBroadcastFeedback(
     conventionId: ConventionId,
-  ): Promise<ConventionLastBroadcastFeedbackResponse> {
+  ): Promise<BroadcastFeedback | null> {
     return (
       this.#broadcastFeedbacks
         .filter(

--- a/back/src/domains/core/saved-errors/adapters/InMemoryBroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/InMemoryBroadcastFeedbacksRepository.ts
@@ -65,6 +65,17 @@ export class InMemoryBroadcastFeedbacksRepository
     );
   }
 
+  public async getBroadcastFeedbacksByConventionId(
+    conventionId: ConventionId,
+  ): Promise<BroadcastFeedback[]> {
+    return this.#broadcastFeedbacks
+      .filter((broadcast) => broadcast.conventionId === conventionId)
+      .sort(
+        (a, b) =>
+          new Date(a.occurredAt).getTime() - new Date(b.occurredAt).getTime(),
+      );
+  }
+
   public get broadcastFeedbacks(): BroadcastFeedback[] {
     return this.#broadcastFeedbacks;
   }

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
@@ -29,8 +29,8 @@ import { PgAgencyRepository } from "../../../agency/adapters/PgAgencyRepository"
 import { PgConventionRepository } from "../../../convention/adapters/PgConventionRepository";
 import { PgUserRepository } from "../../../core/authentication/connected-user/adapters/PgUserRepository";
 import {
-  broadcastToFtServiceName,
   type BroadcastFeedbacksRepository,
+  broadcastToFtServiceName,
 } from "../ports/BroadcastFeedbacksRepository";
 import { InMemoryBroadcastFeedbacksRepository } from "./InMemoryBroadcastFeedbacksRepository";
 import { PgBroadcastFeedbacksRepository } from "./PgBroadcastFeedbacksRepository";
@@ -471,113 +471,106 @@ describe("PgBroadcastFeedbacksRepository", () => {
     });
   });
 
-  describe.each(["Pg", "InMemory"] as const)(
-    "%s getBroadcastFeedbacksByConventionId",
-    (adapter) => {
-      let repository: BroadcastFeedbacksRepository;
+  describe.each([
+    "Pg",
+    "InMemory",
+  ] as const)("%s getBroadcastFeedbacksByConventionId", (adapter) => {
+    let repository: BroadcastFeedbacksRepository;
 
-      beforeEach(() => {
-        repository =
-          adapter === "Pg"
-            ? pgBroadcastFeedbacksRepository
-            : new InMemoryBroadcastFeedbacksRepository();
+    beforeEach(() => {
+      repository =
+        adapter === "Pg"
+          ? pgBroadcastFeedbacksRepository
+          : new InMemoryBroadcastFeedbacksRepository();
+    });
+
+    it("returns an empty array when there is no broadcast feedback", async () => {
+      const result =
+        await repository.getBroadcastFeedbacksByConventionId(someConventionId);
+
+      expectToEqual(result, []);
+    });
+
+    it("returns all feedbacks for a convention ordered by occurredAt ascending", async () => {
+      const conventionId = someConventionId;
+
+      const firstBroadcast = await makeBroadcastFeedback({
+        conventionId,
+        serviceName: broadcastToFtServiceName,
+        kind: "success",
+        occurredAt: new Date("2024-07-01"),
+      });
+      const secondBroadcast = await makeBroadcastFeedback({
+        conventionId,
+        serviceName: broadcastToFtServiceName,
+        kind: "error",
+        occurredAt: new Date("2024-07-15"),
+      });
+      const thirdBroadcast = await makeBroadcastFeedback({
+        conventionId,
+        serviceName: broadcastToFtServiceName,
+        kind: "error",
+        occurredAt: new Date("2024-07-31"),
       });
 
-      it("returns an empty array when there is no broadcast feedback", async () => {
-        const result =
-          await repository.getBroadcastFeedbacksByConventionId(
-            someConventionId,
-          );
+      await repository.save(thirdBroadcast);
+      await repository.save(firstBroadcast);
+      await repository.save(secondBroadcast);
 
-        expectToEqual(result, []);
+      const result =
+        await repository.getBroadcastFeedbacksByConventionId(conventionId);
+
+      expectToEqual(
+        result.map(({ occurredAt, serviceName, conventionId: id }) => ({
+          occurredAt,
+          serviceName,
+          conventionId: id,
+        })),
+        [
+          {
+            occurredAt: firstBroadcast.occurredAt,
+            serviceName: firstBroadcast.serviceName,
+            conventionId,
+          },
+          {
+            occurredAt: secondBroadcast.occurredAt,
+            serviceName: secondBroadcast.serviceName,
+            conventionId,
+          },
+          {
+            occurredAt: thirdBroadcast.occurredAt,
+            serviceName: thirdBroadcast.serviceName,
+            conventionId,
+          },
+        ],
+      );
+    });
+
+    it("isolates feedbacks by conventionId", async () => {
+      const broadcastForConvention1 = await makeBroadcastFeedback({
+        conventionId: someConventionId,
+        serviceName: broadcastToFtServiceName,
+        kind: "success",
+        occurredAt: new Date("2024-07-01"),
+      });
+      const broadcastForConvention2 = await makeBroadcastFeedback({
+        conventionId: anotherConventionId,
+        serviceName: broadcastToFtServiceName,
+        kind: "error",
+        occurredAt: new Date("2024-07-15"),
       });
 
-      it("returns all feedbacks for a convention ordered by occurredAt ascending", async () => {
-        const conventionId = someConventionId;
+      await repository.save(broadcastForConvention1);
+      await repository.save(broadcastForConvention2);
 
-        const firstBroadcast = await makeBroadcastFeedback({
-          conventionId,
-          serviceName: broadcastToFtServiceName,
-          kind: "success",
-          occurredAt: new Date("2024-07-01"),
-        });
-        const secondBroadcast = await makeBroadcastFeedback({
-          conventionId,
-          serviceName: broadcastToFtServiceName,
-          kind: "error",
-          occurredAt: new Date("2024-07-15"),
-        });
-        const thirdBroadcast = await makeBroadcastFeedback({
-          conventionId,
-          serviceName: broadcastToFtServiceName,
-          kind: "error",
-          occurredAt: new Date("2024-07-31"),
-        });
+      const result =
+        await repository.getBroadcastFeedbacksByConventionId(someConventionId);
 
-        await repository.save(thirdBroadcast);
-        await repository.save(firstBroadcast);
-        await repository.save(secondBroadcast);
-
-        const result =
-          await repository.getBroadcastFeedbacksByConventionId(conventionId);
-
-        expectToEqual(
-          result.map(({ occurredAt, serviceName, conventionId: id }) => ({
-            occurredAt,
-            serviceName,
-            conventionId: id,
-          })),
-          [
-            {
-              occurredAt: firstBroadcast.occurredAt,
-              serviceName: firstBroadcast.serviceName,
-              conventionId,
-            },
-            {
-              occurredAt: secondBroadcast.occurredAt,
-              serviceName: secondBroadcast.serviceName,
-              conventionId,
-            },
-            {
-              occurredAt: thirdBroadcast.occurredAt,
-              serviceName: thirdBroadcast.serviceName,
-              conventionId,
-            },
-          ],
-        );
-      });
-
-      it("isolates feedbacks by conventionId", async () => {
-        const broadcastForConvention1 = await makeBroadcastFeedback({
-          conventionId: someConventionId,
-          serviceName: broadcastToFtServiceName,
-          kind: "success",
-          occurredAt: new Date("2024-07-01"),
-        });
-        const broadcastForConvention2 = await makeBroadcastFeedback({
-          conventionId: anotherConventionId,
-          serviceName: broadcastToFtServiceName,
-          kind: "error",
-          occurredAt: new Date("2024-07-15"),
-        });
-
-        await repository.save(broadcastForConvention1);
-        await repository.save(broadcastForConvention2);
-
-        const result =
-          await repository.getBroadcastFeedbacksByConventionId(
-            someConventionId,
-          );
-
-        expectToEqual(result.length, 1);
-        expectToEqual(result[0]?.conventionId, someConventionId);
-        expectToEqual(
-          result[0]?.occurredAt,
-          broadcastForConvention1.occurredAt,
-        );
-      });
-    },
-  );
+      expectToEqual(result.length, 1);
+      expectToEqual(result[0]?.conventionId, someConventionId);
+      expectToEqual(result[0]?.occurredAt, broadcastForConvention1.occurredAt);
+    });
+  });
 });
 
 const makeBroadcastFeedback = async (params: {

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
@@ -28,7 +28,11 @@ import { makeUniqueUserForTest } from "../../../../utils/user";
 import { PgAgencyRepository } from "../../../agency/adapters/PgAgencyRepository";
 import { PgConventionRepository } from "../../../convention/adapters/PgConventionRepository";
 import { PgUserRepository } from "../../../core/authentication/connected-user/adapters/PgUserRepository";
-import { broadcastToFtServiceName } from "../ports/BroadcastFeedbacksRepository";
+import {
+  broadcastToFtServiceName,
+  type BroadcastFeedbacksRepository,
+} from "../ports/BroadcastFeedbacksRepository";
+import { InMemoryBroadcastFeedbacksRepository } from "./InMemoryBroadcastFeedbacksRepository";
 import { PgBroadcastFeedbacksRepository } from "./PgBroadcastFeedbacksRepository";
 
 const someConventionId: ConventionId = "a07af28e-9c7b-4845-91ee-71020860faa8";
@@ -466,6 +470,114 @@ describe("PgBroadcastFeedbacksRepository", () => {
       });
     });
   });
+
+  describe.each(["Pg", "InMemory"] as const)(
+    "%s getBroadcastFeedbacksByConventionId",
+    (adapter) => {
+      let repository: BroadcastFeedbacksRepository;
+
+      beforeEach(() => {
+        repository =
+          adapter === "Pg"
+            ? pgBroadcastFeedbacksRepository
+            : new InMemoryBroadcastFeedbacksRepository();
+      });
+
+      it("returns an empty array when there is no broadcast feedback", async () => {
+        const result =
+          await repository.getBroadcastFeedbacksByConventionId(
+            someConventionId,
+          );
+
+        expectToEqual(result, []);
+      });
+
+      it("returns all feedbacks for a convention ordered by occurredAt ascending", async () => {
+        const conventionId = someConventionId;
+
+        const firstBroadcast = await makeBroadcastFeedback({
+          conventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "success",
+          occurredAt: new Date("2024-07-01"),
+        });
+        const secondBroadcast = await makeBroadcastFeedback({
+          conventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "error",
+          occurredAt: new Date("2024-07-15"),
+        });
+        const thirdBroadcast = await makeBroadcastFeedback({
+          conventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "error",
+          occurredAt: new Date("2024-07-31"),
+        });
+
+        await repository.save(thirdBroadcast);
+        await repository.save(firstBroadcast);
+        await repository.save(secondBroadcast);
+
+        const result =
+          await repository.getBroadcastFeedbacksByConventionId(conventionId);
+
+        expectToEqual(
+          result.map(({ occurredAt, serviceName, conventionId: id }) => ({
+            occurredAt,
+            serviceName,
+            conventionId: id,
+          })),
+          [
+            {
+              occurredAt: firstBroadcast.occurredAt,
+              serviceName: firstBroadcast.serviceName,
+              conventionId,
+            },
+            {
+              occurredAt: secondBroadcast.occurredAt,
+              serviceName: secondBroadcast.serviceName,
+              conventionId,
+            },
+            {
+              occurredAt: thirdBroadcast.occurredAt,
+              serviceName: thirdBroadcast.serviceName,
+              conventionId,
+            },
+          ],
+        );
+      });
+
+      it("isolates feedbacks by conventionId", async () => {
+        const broadcastForConvention1 = await makeBroadcastFeedback({
+          conventionId: someConventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "success",
+          occurredAt: new Date("2024-07-01"),
+        });
+        const broadcastForConvention2 = await makeBroadcastFeedback({
+          conventionId: anotherConventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "error",
+          occurredAt: new Date("2024-07-15"),
+        });
+
+        await repository.save(broadcastForConvention1);
+        await repository.save(broadcastForConvention2);
+
+        const result =
+          await repository.getBroadcastFeedbacksByConventionId(
+            someConventionId,
+          );
+
+        expectToEqual(result.length, 1);
+        expectToEqual(result[0]?.conventionId, someConventionId);
+        expectToEqual(
+          result[0]?.occurredAt,
+          broadcastForConvention1.occurredAt,
+        );
+      });
+    },
+  );
 });
 
 const makeBroadcastFeedback = async (params: {

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
@@ -471,106 +471,113 @@ describe("PgBroadcastFeedbacksRepository", () => {
     });
   });
 
-  describe.each([
-    "Pg",
-    "InMemory",
-  ] as const)("%s getBroadcastFeedbacksByConventionId", (adapter) => {
-    let repository: BroadcastFeedbacksRepository;
+  describe.each(["Pg", "InMemory"] as const)(
+    "%s getBroadcastFeedbacksByConventionId",
+    (adapter) => {
+      let repository: BroadcastFeedbacksRepository;
 
-    beforeEach(() => {
-      repository =
-        adapter === "Pg"
-          ? pgBroadcastFeedbacksRepository
-          : new InMemoryBroadcastFeedbacksRepository();
-    });
-
-    it("returns an empty array when there is no broadcast feedback", async () => {
-      const result =
-        await repository.getBroadcastFeedbacksByConventionId(someConventionId);
-
-      expectToEqual(result, []);
-    });
-
-    it("returns all feedbacks for a convention ordered by occurredAt ascending", async () => {
-      const conventionId = someConventionId;
-
-      const firstBroadcast = await makeBroadcastFeedback({
-        conventionId,
-        serviceName: broadcastToFtServiceName,
-        kind: "success",
-        occurredAt: new Date("2024-07-01"),
-      });
-      const secondBroadcast = await makeBroadcastFeedback({
-        conventionId,
-        serviceName: broadcastToFtServiceName,
-        kind: "error",
-        occurredAt: new Date("2024-07-15"),
-      });
-      const thirdBroadcast = await makeBroadcastFeedback({
-        conventionId,
-        serviceName: broadcastToFtServiceName,
-        kind: "error",
-        occurredAt: new Date("2024-07-31"),
+      beforeEach(() => {
+        repository =
+          adapter === "Pg"
+            ? pgBroadcastFeedbacksRepository
+            : new InMemoryBroadcastFeedbacksRepository();
       });
 
-      await repository.save(thirdBroadcast);
-      await repository.save(firstBroadcast);
-      await repository.save(secondBroadcast);
+      it("returns an empty array when there is no broadcast feedback", async () => {
+        const result =
+          await repository.getBroadcastFeedbacksByConventionId(
+            someConventionId,
+          );
 
-      const result =
-        await repository.getBroadcastFeedbacksByConventionId(conventionId);
-
-      expectToEqual(
-        result.map(({ occurredAt, serviceName, conventionId: id }) => ({
-          occurredAt,
-          serviceName,
-          conventionId: id,
-        })),
-        [
-          {
-            occurredAt: firstBroadcast.occurredAt,
-            serviceName: firstBroadcast.serviceName,
-            conventionId,
-          },
-          {
-            occurredAt: secondBroadcast.occurredAt,
-            serviceName: secondBroadcast.serviceName,
-            conventionId,
-          },
-          {
-            occurredAt: thirdBroadcast.occurredAt,
-            serviceName: thirdBroadcast.serviceName,
-            conventionId,
-          },
-        ],
-      );
-    });
-
-    it("isolates feedbacks by conventionId", async () => {
-      const broadcastForConvention1 = await makeBroadcastFeedback({
-        conventionId: someConventionId,
-        serviceName: broadcastToFtServiceName,
-        kind: "success",
-        occurredAt: new Date("2024-07-01"),
-      });
-      const broadcastForConvention2 = await makeBroadcastFeedback({
-        conventionId: anotherConventionId,
-        serviceName: broadcastToFtServiceName,
-        kind: "error",
-        occurredAt: new Date("2024-07-15"),
+        expectToEqual(result, []);
       });
 
-      await repository.save(broadcastForConvention1);
-      await repository.save(broadcastForConvention2);
+      it("returns all feedbacks for a convention ordered by occurredAt ascending", async () => {
+        const conventionId = someConventionId;
 
-      const result =
-        await repository.getBroadcastFeedbacksByConventionId(someConventionId);
+        const firstBroadcast = await makeBroadcastFeedback({
+          conventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "success",
+          occurredAt: new Date("2024-07-01"),
+        });
+        const secondBroadcast = await makeBroadcastFeedback({
+          conventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "error",
+          occurredAt: new Date("2024-07-15"),
+        });
+        const thirdBroadcast = await makeBroadcastFeedback({
+          conventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "error",
+          occurredAt: new Date("2024-07-31"),
+        });
 
-      expectToEqual(result.length, 1);
-      expectToEqual(result[0]?.conventionId, someConventionId);
-      expectToEqual(result[0]?.occurredAt, broadcastForConvention1.occurredAt);
-    });
-  });
+        await repository.save(thirdBroadcast);
+        await repository.save(firstBroadcast);
+        await repository.save(secondBroadcast);
+
+        const result =
+          await repository.getBroadcastFeedbacksByConventionId(conventionId);
+
+        expectToEqual(
+          result.map(({ occurredAt, serviceName, conventionId: id }) => ({
+            occurredAt,
+            serviceName,
+            conventionId: id,
+          })),
+          [
+            {
+              occurredAt: firstBroadcast.occurredAt,
+              serviceName: firstBroadcast.serviceName,
+              conventionId,
+            },
+            {
+              occurredAt: secondBroadcast.occurredAt,
+              serviceName: secondBroadcast.serviceName,
+              conventionId,
+            },
+            {
+              occurredAt: thirdBroadcast.occurredAt,
+              serviceName: thirdBroadcast.serviceName,
+              conventionId,
+            },
+          ],
+        );
+      });
+
+      it("isolates feedbacks by conventionId", async () => {
+        const broadcastForConvention1 = await makeBroadcastFeedback({
+          conventionId: someConventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "success",
+          occurredAt: new Date("2024-07-01"),
+        });
+        const broadcastForConvention2 = await makeBroadcastFeedback({
+          conventionId: anotherConventionId,
+          serviceName: broadcastToFtServiceName,
+          kind: "error",
+          occurredAt: new Date("2024-07-15"),
+        });
+
+        await repository.save(broadcastForConvention1);
+        await repository.save(broadcastForConvention2);
+
+        const result =
+          await repository.getBroadcastFeedbacksByConventionId(
+            someConventionId,
+          );
+
+        expectToEqual(result.length, 1);
+        expectToEqual(result[0]?.conventionId, someConventionId);
+        expectToEqual(
+          result[0]?.occurredAt,
+          broadcastForConvention1.occurredAt,
+        );
+      });
+    },
+  );
 });
 
 const makeBroadcastFeedback = async (params: {

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
@@ -73,6 +73,49 @@ export class PgBroadcastFeedbacksRepository
     };
   }
 
+  public async getBroadcastFeedbacksByConventionId(
+    id: ConventionId,
+  ): Promise<BroadcastFeedback[]> {
+    const rows = await this.transaction
+      .selectFrom("broadcast_feedbacks as bf")
+      .where("bf.convention_id", "=", id)
+      .select([
+        "bf.consumer_id as consumerId",
+        "bf.consumer_name as consumerName",
+        "bf.service_name as serviceName",
+        "bf.subscriber_error_feedback as subscriberErrorFeedback",
+        "bf.request_params as requestParams",
+        sql<DateTimeIsoString>`date_to_iso(bf.occurred_at)`.as("occurredAt"),
+        "bf.handled_by_agency as handledByAgency",
+        "bf.response as response",
+        "bf.convention_id as conventionId",
+        "bf.agency_id as agencyId",
+      ])
+      .orderBy("bf.occurred_at", "asc")
+      .execute();
+
+    return rows.flatMap((row) => {
+      if (!row.conventionId || !row.agencyId) return [];
+
+      return [
+        {
+          consumerId: row.consumerId,
+          consumerName: row.consumerName,
+          conventionId: row.conventionId,
+          agencyId: row.agencyId,
+          handledByAgency: row.handledByAgency,
+          occurredAt: row.occurredAt,
+          requestParams: row.requestParams,
+          serviceName: row.serviceName,
+          response: row.response,
+          subscriberErrorFeedback: row.subscriberErrorFeedback
+            ? row.subscriberErrorFeedback
+            : undefined,
+        },
+      ];
+    });
+  }
+
   async #getAgencyId(conventionId: ConventionId): Promise<AgencyId | null> {
     const convention = await this.transaction
       .selectFrom("conventions")

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
@@ -3,7 +3,6 @@ import {
   type AgencyId,
   type BroadcastFeedback,
   type ConventionId,
-  type ConventionLastBroadcastFeedbackResponse,
   type DateTimeIsoString,
   errors,
 } from "shared";
@@ -18,7 +17,7 @@ export class PgBroadcastFeedbacksRepository
 
   public async getLastBroadcastFeedback(
     id: ConventionId,
-  ): Promise<ConventionLastBroadcastFeedbackResponse> {
+  ): Promise<BroadcastFeedback | null> {
     const result = await this.transaction
       .with("latest_feedback", (qb) =>
         qb

--- a/back/src/domains/core/saved-errors/ports/BroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/ports/BroadcastFeedbacksRepository.ts
@@ -14,4 +14,7 @@ export interface BroadcastFeedbacksRepository {
   getLastBroadcastFeedback: (
     id: ConventionId,
   ) => Promise<BroadcastFeedback | null>;
+  getBroadcastFeedbacksByConventionId: (
+    id: ConventionId,
+  ) => Promise<BroadcastFeedback[]>;
 }

--- a/back/src/domains/core/saved-errors/ports/BroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/ports/BroadcastFeedbacksRepository.ts
@@ -1,8 +1,4 @@
-import type {
-  BroadcastFeedback,
-  ConventionId,
-  ConventionLastBroadcastFeedbackResponse,
-} from "shared";
+import type { BroadcastFeedback, ConventionId } from "shared";
 
 export const broadcastToPartnersServiceName =
   "BroadcastToPartnersOnConventionUpdates";
@@ -17,5 +13,5 @@ export interface BroadcastFeedbacksRepository {
   markPartnersErroredConventionAsHandled: (id: ConventionId) => Promise<void>;
   getLastBroadcastFeedback: (
     id: ConventionId,
-  ) => Promise<ConventionLastBroadcastFeedbackResponse>;
+  ) => Promise<BroadcastFeedback | null>;
 }

--- a/front/src/app/components/admin/conventions/ConventionManageActions.tsx
+++ b/front/src/app/components/admin/conventions/ConventionManageActions.tsx
@@ -29,6 +29,7 @@ import type { VerificationAction } from "src/app/components/forms/convention/man
 import { useFeedbackTopic } from "src/app/hooks/feedback.hooks";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { isAssessmentToBeSignedByBeneficiary } from "src/app/utils/assessment.utils";
+import { shouldShowPartnersBroadcastError } from "src/app/utils/broadcast.utils";
 import { getConventionSubStatus } from "src/app/utils/conventionSubStatus";
 import { apiConsumerSelectors } from "src/core-logic/domain/apiConsumer/apiConsumer.selector";
 import { assessmentSlice } from "src/core-logic/domain/assessment/assessment.slice";
@@ -88,9 +89,16 @@ export const ConventionManageActions = ({
     conventionActionSelectors.isLoading,
   );
   const currentUser = useAppSelector(connectedUserSelectors.currentUser);
-  const broadcastErrorFeedback = useAppSelector(
+  const lastBroadcastFeedback = useAppSelector(
     partnersErroredConventionSelectors.lastBroadcastFeedback,
-  )?.subscriberErrorFeedback;
+  );
+  const shouldShowBroadcastError = shouldShowPartnersBroadcastError({
+    isBackofficeAdmin: currentUser?.isBackofficeAdmin ?? false,
+    lastBroadcastFeedback,
+  });
+  const broadcastErrorFeedback = shouldShowBroadcastError
+    ? lastBroadcastFeedback.broadcastFeedback?.subscriberErrorFeedback
+    : undefined;
 
   const feedbacks = useAppSelector(feedbacksSelectors.feedbacks);
   const consumerNames = useAppSelector(apiConsumerSelectors.apiConsumerNames);

--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -40,6 +40,7 @@ import {
   getAssessmentCompletionStatus,
   getAssessmentLabelsAndSeverityByStatus,
 } from "src/app/utils/assessment.utils";
+import { shouldShowPartnersBroadcastError } from "src/app/utils/broadcast.utils";
 import { commonIllustrations } from "src/assets/img/illustrations";
 import { sendAssessmentLinkSlice } from "src/core-logic/domain/assessment/send-assessment-link/sendAssessmentLink.slice";
 import { connectedUserSelectors } from "src/core-logic/domain/connected-user/connectedUser.selectors";
@@ -77,9 +78,11 @@ export const ConventionValidation = ({
   roles,
 }: ConventionValidationProps) => {
   const dispatch = useDispatch();
-  const conventionLastBroadcastFeedback = useAppSelector(
+  const lastBroadcastFeedback = useAppSelector(
     partnersErroredConventionSelectors.lastBroadcastFeedback,
   );
+  const conventionLastBroadcastFeedback =
+    lastBroadcastFeedback.broadcastFeedback;
   const currentUser = useAppSelector(connectedUserSelectors.currentUser);
 
   useScrollTo(
@@ -133,7 +136,10 @@ export const ConventionValidation = ({
     });
 
   const shouldShowConventionLastBroadcastFeedbackErrorInfo =
-    conventionLastBroadcastFeedback?.subscriberErrorFeedback &&
+    shouldShowPartnersBroadcastError({
+      isBackofficeAdmin: currentUser?.isBackofficeAdmin ?? false,
+      lastBroadcastFeedback,
+    }) &&
     hasAllowedRole({
       allowedRoles: [...agencyModifierRoles, "back-office"],
       candidateRoles: roles,
@@ -236,10 +242,10 @@ export const ConventionValidation = ({
       )}
 
       {shouldShowConventionLastBroadcastFeedbackErrorInfo &&
-        conventionLastBroadcastFeedback.subscriberErrorFeedback && (
+        conventionLastBroadcastFeedback?.subscriberErrorFeedback && (
           <SubscriberErrorFeedbackComponent
             subscriberErrorFeedback={
-              conventionLastBroadcastFeedback?.subscriberErrorFeedback
+              conventionLastBroadcastFeedback.subscriberErrorFeedback
             }
             conventionStatus={convention.status}
           />

--- a/front/src/app/utils/broadcast.utils.ts
+++ b/front/src/app/utils/broadcast.utils.ts
@@ -1,0 +1,18 @@
+import type { ConventionLastBroadcastFeedbackResponse } from "shared";
+
+export const shouldShowPartnersBroadcastError = ({
+  isBackofficeAdmin,
+  lastBroadcastFeedback,
+}: {
+  isBackofficeAdmin: boolean;
+  lastBroadcastFeedback: ConventionLastBroadcastFeedbackResponse;
+}): boolean => {
+  const hasSubscriberErrorFeedback =
+    !!lastBroadcastFeedback.broadcastFeedback?.subscriberErrorFeedback;
+  const shouldBeHandled =
+    lastBroadcastFeedback.broadcastFeedback === null
+      ? false
+      : lastBroadcastFeedback.shouldBeHandled;
+
+  return hasSubscriberErrorFeedback && (isBackofficeAdmin || shouldBeHandled);
+};

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.epics.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.epics.ts
@@ -54,7 +54,7 @@ const fetchConventionLastBroadcastFeedbackEpic: PartnersErroredConventionEpic =
             payload.jwt,
           )
           .pipe(
-            map((lastBroadcastFeedback) =>
+            map(({ lastBroadcastFeedback }) =>
               partnersErroredConventionSlice.actions.fetchConventionLastBroadcastFeedbackSucceeded(
                 {
                   lastBroadcastFeedback,

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.epics.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.epics.ts
@@ -54,11 +54,9 @@ const fetchConventionLastBroadcastFeedbackEpic: PartnersErroredConventionEpic =
             payload.jwt,
           )
           .pipe(
-            map(({ lastBroadcastFeedback }) =>
+            map((response) =>
               partnersErroredConventionSlice.actions.fetchConventionLastBroadcastFeedbackSucceeded(
-                {
-                  lastBroadcastFeedback,
-                },
+                response,
               ),
             ),
             catchEpicError((error: Error) =>

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.slice.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.slice.ts
@@ -1,7 +1,7 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type {
+  BroadcastFeedback,
   ConventionId,
-  ConventionLastBroadcastFeedbackResponse,
   ConventionSupportedJwt,
   MarkPartnersErroredConventionAsHandledRequest,
 } from "shared";
@@ -9,7 +9,7 @@ import type { PayloadActionWithFeedbackTopic } from "../feedback/feedback.slice"
 
 export interface PartnersErroredConventionState {
   isLoading: boolean;
-  lastBroadcastFeedback: ConventionLastBroadcastFeedbackResponse;
+  lastBroadcastFeedback: BroadcastFeedback | null;
 }
 
 export const initialPartnersErroredConventionState: PartnersErroredConventionState =
@@ -63,7 +63,7 @@ export const partnersErroredConventionSlice = createSlice({
     fetchConventionLastBroadcastFeedbackSucceeded: (
       state,
       action: PayloadAction<{
-        lastBroadcastFeedback: ConventionLastBroadcastFeedbackResponse;
+        lastBroadcastFeedback: BroadcastFeedback | null;
       }>,
     ) => {
       state.isLoading = false;

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.slice.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.slice.ts
@@ -1,7 +1,7 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type {
-  BroadcastFeedback,
   ConventionId,
+  ConventionLastBroadcastFeedbackResponse,
   ConventionSupportedJwt,
   MarkPartnersErroredConventionAsHandledRequest,
 } from "shared";
@@ -9,13 +9,13 @@ import type { PayloadActionWithFeedbackTopic } from "../feedback/feedback.slice"
 
 export interface PartnersErroredConventionState {
   isLoading: boolean;
-  lastBroadcastFeedback: BroadcastFeedback | null;
+  lastBroadcastFeedback: ConventionLastBroadcastFeedbackResponse;
 }
 
 export const initialPartnersErroredConventionState: PartnersErroredConventionState =
   {
     isLoading: false,
-    lastBroadcastFeedback: null,
+    lastBroadcastFeedback: { broadcastFeedback: null },
   };
 
 type MarkPartnersErroredConventionAsHandledRequestPayload = {
@@ -62,12 +62,10 @@ export const partnersErroredConventionSlice = createSlice({
     },
     fetchConventionLastBroadcastFeedbackSucceeded: (
       state,
-      action: PayloadAction<{
-        lastBroadcastFeedback: BroadcastFeedback | null;
-      }>,
+      action: PayloadAction<ConventionLastBroadcastFeedbackResponse>,
     ) => {
       state.isLoading = false;
-      state.lastBroadcastFeedback = action.payload.lastBroadcastFeedback;
+      state.lastBroadcastFeedback = action.payload;
     },
     fetchConventionLastBroadcastFeedbackFailed: (
       state: PartnersErroredConventionState,

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.test.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.test.ts
@@ -126,7 +126,10 @@ describe("Broadcast feedback in store", () => {
       ),
     );
     dependencies.conventionGateway.getConventionLastBroadcastFeedbackResult$.next(
-      mockBroadcastFeedback,
+      {
+        lastBroadcastFeedback: mockBroadcastFeedback,
+        shouldBeHandled: false,
+      },
     );
 
     expectIsLoadingToBe(false);
@@ -145,7 +148,9 @@ describe("Broadcast feedback in store", () => {
       ),
     );
     dependencies.conventionGateway.getConventionLastBroadcastFeedbackResult$.next(
-      null,
+      {
+        lastBroadcastFeedback: null,
+      },
     );
 
     expectIsLoadingToBe(false);
@@ -199,7 +204,10 @@ describe("Broadcast feedback in store", () => {
       ),
     );
     dependencies.conventionGateway.getConventionLastBroadcastFeedbackResult$.next(
-      broadcastFeedback,
+      {
+        lastBroadcastFeedback: broadcastFeedback,
+        shouldBeHandled: false,
+      },
     );
 
     expect(

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.test.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.test.ts
@@ -127,18 +127,22 @@ describe("Broadcast feedback in store", () => {
     );
     dependencies.conventionGateway.getConventionLastBroadcastFeedbackResult$.next(
       {
-        lastBroadcastFeedback: mockBroadcastFeedback,
-        shouldBeHandled: false,
+        broadcastFeedback: mockBroadcastFeedback,
+        shouldBeHandled: true,
       },
     );
 
     expectIsLoadingToBe(false);
-    expect(
+    expectToEqual(
       store.getState().partnersErroredConvention.lastBroadcastFeedback,
-    ).toEqual(mockBroadcastFeedback);
+      {
+        broadcastFeedback: mockBroadcastFeedback,
+        shouldBeHandled: true,
+      },
+    );
   });
 
-  it("should set lastBroadcastFeedback to null when fetch last broadcast feedback succeeds with null", () => {
+  it("should set lastBroadcastFeedback with null feedback when fetch succeeds with null", () => {
     store.dispatch(
       partnersErroredConventionSlice.actions.fetchConventionLastBroadcastFeedbackRequested(
         {
@@ -149,14 +153,15 @@ describe("Broadcast feedback in store", () => {
     );
     dependencies.conventionGateway.getConventionLastBroadcastFeedbackResult$.next(
       {
-        lastBroadcastFeedback: null,
+        broadcastFeedback: null,
       },
     );
 
     expectIsLoadingToBe(false);
-    expect(
+    expectToEqual(
       store.getState().partnersErroredConvention.lastBroadcastFeedback,
-    ).toBeNull();
+      { broadcastFeedback: null },
+    );
   });
 
   it("should handle error when fetch last broadcast feedback fails", () => {
@@ -176,9 +181,10 @@ describe("Broadcast feedback in store", () => {
 
     expectIsLoadingToBe(false);
 
-    expect(
+    expectToEqual(
       store.getState().partnersErroredConvention.lastBroadcastFeedback,
-    ).toBeNull();
+      { broadcastFeedback: null },
+    );
   });
 
   it("should clear lastBroadcastFeedback when clearLastBroadcastFeedback is dispatched", () => {
@@ -205,22 +211,27 @@ describe("Broadcast feedback in store", () => {
     );
     dependencies.conventionGateway.getConventionLastBroadcastFeedbackResult$.next(
       {
-        lastBroadcastFeedback: broadcastFeedback,
-        shouldBeHandled: false,
+        broadcastFeedback: broadcastFeedback,
+        shouldBeHandled: true,
       },
     );
 
-    expect(
+    expectToEqual(
       store.getState().partnersErroredConvention.lastBroadcastFeedback,
-    ).toEqual(broadcastFeedback);
+      {
+        broadcastFeedback: broadcastFeedback,
+        shouldBeHandled: true,
+      },
+    );
 
     store.dispatch(
       partnersErroredConventionSlice.actions.clearConventionLastBroadcastFeedback(),
     );
 
-    expect(
+    expectToEqual(
       store.getState().partnersErroredConvention.lastBroadcastFeedback,
-    ).toBeNull();
+      { broadcastFeedback: null },
+    );
   });
 
   const expectIsLoadingToBe = (

--- a/shared/src/broadcast/broadcastFeedback.dto.ts
+++ b/shared/src/broadcast/broadcastFeedback.dto.ts
@@ -37,8 +37,8 @@ export type BroadcastFeedback = {
 };
 
 export type ConventionLastBroadcastFeedbackResponse =
-  | { lastBroadcastFeedback: null }
+  | { broadcastFeedback: null }
   | {
-      lastBroadcastFeedback: BroadcastFeedback;
+      broadcastFeedback: BroadcastFeedback;
       shouldBeHandled: boolean;
     };

--- a/shared/src/broadcast/broadcastFeedback.dto.ts
+++ b/shared/src/broadcast/broadcastFeedback.dto.ts
@@ -36,4 +36,9 @@ export type BroadcastFeedback = {
   handledByAgency: boolean;
 };
 
-export type ConventionLastBroadcastFeedbackResponse = BroadcastFeedback | null;
+export type ConventionLastBroadcastFeedbackResponse =
+  | { lastBroadcastFeedback: null }
+  | {
+      lastBroadcastFeedback: BroadcastFeedback;
+      shouldBeHandled: boolean;
+    };

--- a/shared/src/broadcast/broadcastFeedback.schema.ts
+++ b/shared/src/broadcast/broadcastFeedback.schema.ts
@@ -67,11 +67,11 @@ export const conventionLastBroadcastFeedbackResponseSchema: ZodSchemaWithInputMa
   z.union([
     z
       .object({
-        lastBroadcastFeedback: z.null(),
+        broadcastFeedback: z.null(),
       })
       .strict(),
     z.object({
-      lastBroadcastFeedback: nonNullableBroadcastFeedbackSchema,
+      broadcastFeedback: nonNullableBroadcastFeedbackSchema,
       shouldBeHandled: z.boolean(),
     }),
   ]);

--- a/shared/src/broadcast/broadcastFeedback.schema.ts
+++ b/shared/src/broadcast/broadcastFeedback.schema.ts
@@ -10,6 +10,7 @@ import { conventionIdSchema } from "../convention/convention.schema";
 import { dateTimeIsoStringSchema } from "../utils/date";
 import type { ZodSchemaWithInputMatchingOutput } from "../zodUtils";
 import type {
+  BroadcastFeedback,
   BroadcastFeedbackResponse,
   ConventionBroadcastRequestParams,
   ConventionLastBroadcastFeedbackResponse,
@@ -59,5 +60,18 @@ const nonNullableBroadcastFeedbackSchema = z
     },
   );
 
-export const broadcastFeedbackSchema: ZodSchemaWithInputMatchingOutput<ConventionLastBroadcastFeedbackResponse> =
+export const broadcastFeedbackSchema: ZodSchemaWithInputMatchingOutput<BroadcastFeedback | null> =
   nonNullableBroadcastFeedbackSchema.nullable();
+
+export const conventionLastBroadcastFeedbackResponseSchema: ZodSchemaWithInputMatchingOutput<ConventionLastBroadcastFeedbackResponse> =
+  z.union([
+    z
+      .object({
+        lastBroadcastFeedback: z.null(),
+      })
+      .strict(),
+    z.object({
+      lastBroadcastFeedback: nonNullableBroadcastFeedbackSchema,
+      shouldBeHandled: z.boolean(),
+    }),
+  ]);

--- a/shared/src/convention/conventionWithBroadcastFeedback.dto.ts
+++ b/shared/src/convention/conventionWithBroadcastFeedback.dto.ts
@@ -1,5 +1,5 @@
 import type { AgencyId } from "../agency/agency.dto";
-import type { ConventionLastBroadcastFeedbackResponse } from "../broadcast/broadcastFeedback.dto";
+import type { BroadcastFeedback } from "../broadcast/broadcastFeedback.dto";
 import type {
   PaginationQueryParams,
   WithRequiredPagination,
@@ -17,7 +17,7 @@ export type ConventionWithBroadcastFeedback = {
   id: ConventionId;
   status: ConventionStatus;
   beneficiary: WithFirstnameAndLastname;
-  lastBroadcastFeedback: ConventionLastBroadcastFeedbackResponse;
+  lastBroadcastFeedback: BroadcastFeedback | null;
   agencyReferent: WithOptionalFirstnameAndLastname | null;
   agencyId: AgencyId;
 };

--- a/shared/src/routes/convention.routes.ts
+++ b/shared/src/routes/convention.routes.ts
@@ -12,7 +12,7 @@ import {
   legacyAssessmentDtoSchema,
   signAssessmentRequestDtoSchema,
 } from "../assessment/assessment.schema";
-import { broadcastFeedbackSchema } from "../broadcast/broadcastFeedback.schema";
+import { conventionLastBroadcastFeedbackResponseSchema } from "../broadcast/broadcastFeedback.schema";
 import { addConventionInputSchema } from "../convention/addConventionInput";
 import { paginatedAgencyUserConventionListSchema } from "../convention/agencyUserConventionList.schema";
 import {
@@ -453,7 +453,7 @@ export const authenticatedConventionRoutes = defineRoutes({
     method: "get",
     ...withAuthorizationHeaders,
     responses: {
-      200: broadcastFeedbackSchema,
+      200: conventionLastBroadcastFeedbackResponseSchema,
       400: httpErrorSchema,
       401: httpErrorSchema,
       403: httpErrorSchema,


### PR DESCRIPTION
Fixes #5644

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
