### PR TITLE
#5665 - Reset les filtres de la recherche après un retour en arrière

### DIFF
--- a/front/src/app/pages/search/SearchPage.tsx
+++ b/front/src/app/pages/search/SearchPage.tsx
@@ -40,6 +40,7 @@ import {
   canSubmitSearch,
 } from "src/app/pages/search/SearchPage.utils";
 import labonneboiteLogoUrl from "src/assets/img/logo-lbb-centered.png";
+import { appellationSlice } from "src/core-logic/domain/appellation/appellation.slice";
 import { featureFlagSelectors } from "src/core-logic/domain/featureFlags/featureFlags.selector";
 import { geosearchSlice } from "src/core-logic/domain/geosearch/geosearch.slice";
 import { nafSlice } from "src/core-logic/domain/naf/naf.slice";
@@ -238,7 +239,21 @@ export const SearchPage = ({
   useScrollTo(pagination?.currentPage ?? 1);
 
   useEffect(() => {
-    if (keys(routeParams).length === 0) return;
+    if (keys(routeParams).length === 0) {
+      setSearchMade(null);
+      reset(initialValues);
+      dispatch(
+        geosearchSlice.actions.clearLocatorDataRequested({
+          locator: "search-form-place",
+        }),
+      );
+      dispatch(
+        appellationSlice.actions.clearLocatorDataRequested({
+          locator: "search-form-appellation",
+        }),
+      );
+      return;
+    }
     const valuesFromUrl = buildValuesFromRouteParams(routeParams);
     if (!canSubmitSearch(valuesFromUrl)) return;
     setSearchMade(valuesFromUrl);
@@ -256,6 +271,7 @@ export const SearchPage = ({
     reset,
     dispatch,
     isExternal,
+    initialValues,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
