### PR TITLE
#5648 - Trier le tableau des conventions prescripteur par date de soumission

### DIFF
--- a/front/src/app/components/agency/agency-dashboard/ConventionList.tsx
+++ b/front/src/app/components/agency/agency-dashboard/ConventionList.tsx
@@ -274,7 +274,7 @@ export const ConventionList = () => {
       dispatch(
         conventionListSlice.actions.fetchConventionListRequested({
           filters: {
-            sortBy: "dateStart",
+            sortBy: "dateSubmission",
             sortDirection: "desc",
             page: 1,
             perPage: 10,

--- a/front/src/core-logic/domain/connected-user/conventionList/connectedUserConventionList.slice.ts
+++ b/front/src/core-logic/domain/connected-user/conventionList/connectedUserConventionList.slice.ts
@@ -37,7 +37,7 @@ export const initialConventionWithPagination: DataWithPagination<AgencyUserConve
     numberPerPage: defaultPerPageInWebPagination,
   },
   filters: {
-    sortBy: "dateStart",
+    sortBy: "dateSubmission",
     sortDirection: "desc",
     page: 1,
     perPage: defaultPerPageInWebPagination,

--- a/front/src/core-logic/domain/connected-user/conventionList/connectedUserConventionList.test.ts
+++ b/front/src/core-logic/domain/connected-user/conventionList/connectedUserConventionList.test.ts
@@ -77,7 +77,7 @@ describe("ConnectedUserConventionList", () => {
         conventionListSlice.actions.fetchConventionListRequested({
           jwt,
           filters: {
-            sortBy: "dateStart",
+            sortBy: "dateSubmission",
             sortDirection: "desc",
             page: 1,
             perPage: defaultPerPageInWebPagination,
@@ -98,7 +98,7 @@ describe("ConnectedUserConventionList", () => {
         conventionsWithPagination: {
           ...conventionsWithPagination,
           filters: {
-            sortBy: "dateStart",
+            sortBy: "dateSubmission",
             sortDirection: "desc",
             page: 1,
             perPage: defaultPerPageInWebPagination,
@@ -114,7 +114,7 @@ describe("ConnectedUserConventionList", () => {
         conventionListSlice.actions.fetchConventionListRequested({
           jwt,
           filters: {
-            sortBy: "dateStart",
+            sortBy: "dateSubmission",
             sortDirection: "desc",
             page: 1,
             perPage: defaultPerPageInWebPagination,
@@ -178,7 +178,7 @@ describe("ConnectedUserConventionList", () => {
         conventionListSlice.actions.fetchConventionListRequested({
           jwt,
           filters: {
-            sortBy: "dateStart",
+            sortBy: "dateSubmission",
             sortDirection: "desc",
             page: 1,
             perPage: defaultPerPageInWebPagination,
@@ -194,7 +194,7 @@ describe("ConnectedUserConventionList", () => {
         conventionsWithPagination: {
           ...conventionsWithPagination,
           filters: {
-            sortBy: "dateStart",
+            sortBy: "dateSubmission",
             sortDirection: "desc",
             page: 1,
             perPage: defaultPerPageInWebPagination,


### PR DESCRIPTION
Fixes #5648

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
