### PR TITLE
#5607 - Demander l'accès à un organisme depuis l'onglet Mes organismes

### DIFF
--- a/front/src/app/components/agency/agency-dashboard/tabs/AgencyAdminTabContent.tsx
+++ b/front/src/app/components/agency/agency-dashboard/tabs/AgencyAdminTabContent.tsx
@@ -13,7 +13,7 @@ import {
   type AgencyRight,
   type ConnectedUser,
   domElementIds,
-  immersionFacileAgencyRegistrationHelpFormUrl,
+  frontRoutes,
 } from "shared";
 import { AgencyRightsTable } from "src/app/components/agency/agencies-table/AgencyRightsTable";
 import { AgencyAdminUsersToReview } from "src/app/components/agency/agency-dashboard/AgencyAdminUsersToReview";
@@ -112,9 +112,9 @@ export const AgencyAdminTabContent = ({
         titleAction={
           <Button
             id={domElementIds.agencyDashboard.registerAgencies.newAgencyButton}
-            linkProps={{ href: immersionFacileAgencyRegistrationHelpFormUrl }}
+            linkProps={frontRoutes.myAccountAgencyRegistration().link}
           >
-            Inscrire un nouvel organisme
+            Demander l'accès à un organisme
           </Button>
         }
       >

--- a/front/src/app/components/agency/agency-dashboard/tabs/AgencyAdminTabContent.tsx
+++ b/front/src/app/components/agency/agency-dashboard/tabs/AgencyAdminTabContent.tsx
@@ -112,7 +112,11 @@ export const AgencyAdminTabContent = ({
         titleAction={
           <Button
             id={domElementIds.agencyDashboard.registerAgencies.newAgencyButton}
-            linkProps={frontRoutes.myAccountAgencyRegistration().link}
+            linkProps={
+              frontRoutes.agencyRegistration({
+                fromRoute: "agencyDashboardAgencies",
+              }).link
+            }
           >
             Demander l'accès à un organisme
           </Button>

--- a/front/src/app/components/user-profile/UserProfile.tsx
+++ b/front/src/app/components/user-profile/UserProfile.tsx
@@ -159,7 +159,7 @@ export const UserProfile = ({
                   id={domElementIds.myAccount.registerAgenciesSearchLink}
                   priority="primary"
                   linkProps={{
-                    href: `${frontRoutes.myAccountAgencyRegistration().href}`,
+                    href: `${frontRoutes.agencyRegistration({ fromRoute: "myAccount" }).href}`,
                   }}
                   iconId="fr-icon-add-line"
                   className={fr.cx("fr-ml-auto")}
@@ -322,7 +322,9 @@ const myProfileEmptyContent: Record<UserProfileTabId, ReactNode> = {
         <Button
           id={domElementIds.myAccount.registerAgencyButton}
           priority="primary"
-          linkProps={frontRoutes.myAccountAgencyRegistration().link}
+          linkProps={
+            frontRoutes.agencyRegistration({ fromRoute: "myAccount" }).link
+          }
           className={fr.cx("fr-ml-auto")}
           iconId="fr-icon-add-line"
         >

--- a/front/src/app/contents/breadcrumbs/breadcrumbs.ts
+++ b/front/src/app/contents/breadcrumbs/breadcrumbs.ts
@@ -101,9 +101,9 @@ export const breadcrumbs: Breadcrumbs<FrontRouteKeys> = {
     label: "Mon profil",
     route: frontRoutes.myAccount(),
     children: {
-      myAccountAgencyRegistration: {
+      agencyRegistration: {
         label: "Demander l'accès à des organismes",
-        route: frontRoutes.myAccountAgencyRegistration(),
+        route: frontRoutes.agencyRegistration({ fromRoute: "myAccount" }),
       },
       myAccountEstablishmentRegistration: {
         label: "Se rattacher à une entreprise",

--- a/front/src/app/pages/auth/ConnectedPrivateRoutePage.tsx
+++ b/front/src/app/pages/auth/ConnectedPrivateRoutePage.tsx
@@ -127,7 +127,7 @@ type ConnectPrivateRoute =
   | Route<typeof frontRoutes.formEstablishment>
   | Route<typeof frontRoutes.myAccount>
   | Route<typeof frontRoutes.myAccountAgencies>
-  | Route<typeof frontRoutes.myAccountAgencyRegistration>
+  | Route<typeof frontRoutes.agencyRegistration>
   | Route<typeof frontRoutes.myAccountEstablishments>
   | Route<typeof frontRoutes.myAccountEstablishmentRegistration>
   | Route<typeof frontRoutes.addAgency>

--- a/front/src/app/pages/user/tabs/RequestAgencyRegistrationTab.tsx
+++ b/front/src/app/pages/user/tabs/RequestAgencyRegistrationTab.tsx
@@ -1,16 +1,47 @@
 import { fr } from "@codegouvfr/react-dsfr";
+import { Breadcrumb } from "@codegouvfr/react-dsfr/Breadcrumb";
 import Button from "@codegouvfr/react-dsfr/Button";
 import { Loader, PageHeader } from "react-design-system";
-import { frontRoutes } from "shared";
-import { Breadcrumbs } from "src/app/components/Breadcrumbs";
+import {
+  type AgencyRegistrationFromRoute,
+  domElementIds,
+  frontRoutes,
+} from "shared";
 import { Feedback } from "src/app/components/feedback/Feedback";
 import { RegisterAgenciesForm } from "src/app/components/forms/register-agencies/RegisterAgenciesForm";
+import { defaultAncestor } from "src/app/contents/breadcrumbs/breadcrumbs";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { connectedUserSelectors } from "src/core-logic/domain/connected-user/connectedUser.selectors";
+import type { Route } from "type-route";
 
-export const RequestAgencyRegistrationTab = () => {
+const defaultAgencyRegistrationFromRoute: AgencyRegistrationFromRoute =
+  "myAccount";
+
+const agencyRegistrationOriginNavigation: Record<
+  AgencyRegistrationFromRoute,
+  { backLabel: string; breadcrumbLabel: string }
+> = {
+  myAccount: {
+    backLabel: "Retourner sur mon profil",
+    breadcrumbLabel: "Mon profil",
+  },
+  agencyDashboardAgencies: {
+    backLabel: "Retour au tableau de bord",
+    breadcrumbLabel: "Tableau de bord",
+  },
+};
+
+export const RequestAgencyRegistrationTab = ({
+  route,
+}: {
+  route: Route<typeof frontRoutes.agencyRegistration>;
+}): JSX.Element => {
   const currentUser = useAppSelector(connectedUserSelectors.currentUser);
   const isLoading = useAppSelector(connectedUserSelectors.isLoading);
+  const fromRoute =
+    route.params.fromRoute ?? defaultAgencyRegistrationFromRoute;
+  const backNavigation = getAgencyRegistrationBackNavigation(fromRoute);
+
   if (isLoading) {
     return <Loader />;
   }
@@ -20,14 +51,15 @@ export const RequestAgencyRegistrationTab = () => {
     <>
       <PageHeader
         title={"Demander l'accès à des organismes"}
-        breadcrumbs={<Breadcrumbs />}
+        breadcrumbs={<AgencyRegistrationBreadcrumbs fromRoute={fromRoute} />}
         badge={
           <Button
-            linkProps={frontRoutes.myAccount().link}
+            id={domElementIds.agencyRegistration.backButton}
+            linkProps={backNavigation.linkProps}
             priority={"secondary"}
             className={fr.cx("fr-mb-6w")}
           >
-            Retourner sur mon profil
+            {backNavigation.label}
           </Button>
         }
       >
@@ -42,3 +74,32 @@ export const RequestAgencyRegistrationTab = () => {
     </>
   );
 };
+
+const getAgencyRegistrationBackNavigation = (
+  fromRoute: AgencyRegistrationFromRoute,
+): {
+  label: string;
+  linkProps: ReturnType<(typeof frontRoutes)["myAccount"]>["link"];
+} => ({
+  label: agencyRegistrationOriginNavigation[fromRoute].backLabel,
+  linkProps: frontRoutes[fromRoute]().link,
+});
+
+const AgencyRegistrationBreadcrumbs = ({
+  fromRoute,
+}: {
+  fromRoute: AgencyRegistrationFromRoute;
+}): JSX.Element => (
+  <div className={fr.cx("fr-container", "fr-mt-4w")}>
+    <Breadcrumb
+      segments={[
+        defaultAncestor,
+        {
+          label: agencyRegistrationOriginNavigation[fromRoute].breadcrumbLabel,
+          linkProps: frontRoutes[fromRoute]().link,
+        },
+      ]}
+      currentPageLabel="Demander l'accès à des organismes"
+    />
+  </div>
+);

--- a/front/src/app/routes/Router.tsx
+++ b/front/src/app/routes/Router.tsx
@@ -318,14 +318,14 @@ const getPageByRouteName: {
       <MyProfileMainTab route={route} />
     </ConnectedPrivateRoutePage>
   ),
-  myAccountAgencyRegistration: (route) => (
+  agencyRegistration: (route) => (
     <ConnectedPrivateRoutePage
       route={route}
       oAuthConnectionPageHeader={
         <PageHeader title="Vous devez vous connecter pour accéder à votre profil" />
       }
     >
-      <RequestAgencyRegistrationTab />
+      <RequestAgencyRegistrationTab route={route} />
     </ConnectedPrivateRoutePage>
   ),
 

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -1368,7 +1368,9 @@ export const domElementIds = {
   establishmentManagement: {},
   myAccountAgencies: {},
   myAccountEstablishments: {},
-  myAccountAgencyRegistration: {},
+  agencyRegistration: {
+    backButton: "im-agency-registration__back-button",
+  },
   agencyDashboardAgencies: {
     userRegistrationToAgency: {
       modal: "im-agency-dashboard-agencies__user-registration-to-agency-modal",

--- a/shared/src/routes/routes.ts
+++ b/shared/src/routes/routes.ts
@@ -179,6 +179,31 @@ export const conventionTemplateFromRouteSerializer: ValueSerializer<
   stringify: (value) => value,
 };
 
+const agencyRegistrationFromRouteValues = [
+  "myAccount",
+  "agencyDashboardAgencies",
+] as const;
+
+export type AgencyRegistrationFromRoute =
+  (typeof agencyRegistrationFromRouteValues)[number];
+
+export const isAgencyRegistrationFromRoute = (
+  value: unknown,
+): value is AgencyRegistrationFromRoute =>
+  typeof value === "string" &&
+  agencyRegistrationFromRouteValues.some((v) => v === value);
+
+export const agencyRegistrationFromRouteSerializer: ValueSerializer<AgencyRegistrationFromRoute> =
+  {
+    parse: (value) => {
+      if (isAgencyRegistrationFromRoute(value)) return value;
+      throw new Error(
+        `Invalid agency registration fromRoute: expected one of ${agencyRegistrationFromRouteValues.join(", ")}, got "${value}"`,
+      );
+    },
+    stringify: (value) => value,
+  };
+
 export const {
   RouteProvider,
   useRoute,
@@ -234,7 +259,14 @@ export const {
   myAccount,
   myAccountAgencies: myAccount.extend("/mes-agences"),
   myAccountEstablishments: myAccount.extend("/mes-etablissements"),
-  myAccountAgencyRegistration: myAccount.extend("/agency-registration"),
+  agencyRegistration: myAccount.extend(
+    {
+      fromRoute: param.query.optional.ofType(
+        agencyRegistrationFromRouteSerializer,
+      ),
+    },
+    () => "/agency-registration",
+  ),
   myAccountEstablishmentRegistration: myAccount.extend(
     { siret: param.query.optional.string },
     () => "/rattachement-entreprise",

--- a/shared/src/routes/routes.ts
+++ b/shared/src/routes/routes.ts
@@ -182,7 +182,7 @@ export const conventionTemplateFromRouteSerializer: ValueSerializer<
 const agencyRegistrationFromRouteValues = [
   "myAccount",
   "agencyDashboardAgencies",
-] as const;
+] as const satisfies FrontRouteKeys[];
 
 export type AgencyRegistrationFromRoute =
   (typeof agencyRegistrationFromRouteValues)[number];
@@ -193,16 +193,17 @@ export const isAgencyRegistrationFromRoute = (
   typeof value === "string" &&
   agencyRegistrationFromRouteValues.some((v) => v === value);
 
-export const agencyRegistrationFromRouteSerializer: ValueSerializer<AgencyRegistrationFromRoute> =
-  {
-    parse: (value) => {
-      if (isAgencyRegistrationFromRoute(value)) return value;
-      throw new Error(
-        `Invalid agency registration fromRoute: expected one of ${agencyRegistrationFromRouteValues.join(", ")}, got "${value}"`,
-      );
-    },
-    stringify: (value) => value,
-  };
+export const agencyRegistrationFromRouteSerializer: ValueSerializer<
+  "myAccount" | "agencyDashboardAgencies"
+> = {
+  parse: (value) => {
+    if (isAgencyRegistrationFromRoute(value)) return value;
+    throw new Error(
+      `Invalid agency registration fromRoute: expected one of ${agencyRegistrationFromRouteValues.join(", ")}, got "${value}"`,
+    );
+  },
+  stringify: (value) => value,
+};
 
 export const {
   RouteProvider,


### PR DESCRIPTION
Fixes #5607

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->

Le premier commit se contentait de changer le bouton de Mes organismes (libellé + lien vers la page de demande d’accès).

Cette page était pensée pour le profil : le retour et le fil d’Ariane disaient toujours « Mon profil ». En y arrivant depuis le tableau de bord, c’était incohérent.

Le second commit aligne le parcours : on mémorise la provenance (fromRoute), le bouton Retour et le fil d’Ariane suivent (tableau de bord ou profil), et la route est renommée agencyRegistration parce que ce n’est plus un écran « profil only ».