### PR TITLE
#5212 - Avoir une seule URL de redirection après connexion OAuth

### DIFF
--- a/back/src/adapters/primary/routers/auth/auth.e2e.test.ts
+++ b/back/src/adapters/primary/routers/auth/auth.e2e.test.ts
@@ -122,7 +122,7 @@ describe("auth router", () => {
           `${displayRouteName(
             authRoutes.initiateLoginByOAuth,
           )} 302 > [ProConnect]/login - 302 > ${displayRouteName(
-            authRoutes.afterEmailOrProConnectOAuthLogin,
+            authRoutes.afterLogin,
           )} 302 > page %s with required connected user params`,
           async (source) => {
             const generatedUserId = "my-user-id";
@@ -169,13 +169,12 @@ describe("auth router", () => {
               },
             });
 
-            const response =
-              await authRoutesClient.afterEmailOrProConnectOAuthLogin({
-                queryParams: {
-                  code: authCode,
-                  state,
-                },
-              });
+            const response = await authRoutesClient.afterLogin({
+              queryParams: {
+                code: authCode,
+                state,
+              },
+            });
 
             if (response.status !== 302)
               throw errors.generic.testError("Response must be 302");
@@ -275,13 +274,12 @@ describe("auth router", () => {
           },
         });
 
-        const response =
-          await authRoutesClient.afterEmailOrProConnectOAuthLogin({
-            queryParams: {
-              code: authCode,
-              state,
-            },
-          });
+        const response = await authRoutesClient.afterLogin({
+          queryParams: {
+            code: authCode,
+            state,
+          },
+        });
 
         expectHttpResponseToEqual(response, {
           body: {},
@@ -311,7 +309,7 @@ describe("auth router", () => {
           `${displayRouteName(
             authRoutes.initiateLoginByEmail,
           )} 200 | EMAIL with connexion link > ${displayRouteName(
-            authRoutes.afterEmailOrProConnectOAuthLogin,
+            authRoutes.afterLogin,
           )} 200 > page %s with required connected user params`,
           async (source) => {
             const email: Email = "mail@email.com";
@@ -358,13 +356,12 @@ describe("auth router", () => {
               throw new Error(
                 `missing code on url ${notification.templatedContent.params.loginLink}`,
               );
-            const response =
-              await authRoutesClient.afterEmailOrProConnectOAuthLogin({
-                queryParams: {
-                  code,
-                  state,
-                },
-              });
+            const response = await authRoutesClient.afterLogin({
+              queryParams: {
+                code,
+                state,
+              },
+            });
 
             if (response.status !== 200)
               throw errors.generic.testError("Response must be 200");
@@ -475,7 +472,7 @@ describe("auth router", () => {
         });
       });
 
-      describe(displayRouteName(authRoutes.afterFTConnectOAuthLogin), () => {
+      describe(displayRouteName(authRoutes.afterLogin), () => {
         it("redirects to convention immersion page with convention draft id", async () => {
           uuidGenerator.new = () => conventionDraftId;
           inMemoryUow.ongoingOAuthRepository.ongoingOAuths = [
@@ -511,7 +508,7 @@ describe("auth router", () => {
             },
           ]);
 
-          const response = await authRoutesClient.afterFTConnectOAuthLogin({
+          const response = await authRoutesClient.afterLogin({
             queryParams: {
               code: ftConnectAuthCode,
               state,
@@ -582,7 +579,7 @@ describe("auth router", () => {
             throw new ManagedFTConnectError("ftConnectNoAuthorisation");
           };
 
-          const response = await authRoutesClient.afterFTConnectOAuthLogin({
+          const response = await authRoutesClient.afterLogin({
             queryParams: {
               code: ftConnectAuthCode,
               state,
@@ -615,7 +612,7 @@ describe("auth router", () => {
             throw new FTConnectError(rawErrorTitle, rawErrorMessage);
           };
 
-          const response = await authRoutesClient.afterFTConnectOAuthLogin({
+          const response = await authRoutesClient.afterLogin({
             queryParams: {
               code: ftConnectAuthCode,
               state,

--- a/back/src/adapters/primary/routers/auth/createAuthRouter.ts
+++ b/back/src/adapters/primary/routers/auth/createAuthRouter.ts
@@ -19,37 +19,29 @@ export const createAuthRouter = (deps: AppDependencies) => {
     ),
   );
 
-  authSharedRouter.afterEmailOrProConnectOAuthLogin(async (req, res) => {
+  authSharedRouter.afterLogin(async (req, res) => {
     return sendHttpResponse(req, res, async () => {
-      const useCaseResult =
-        await deps.useCases.afterOAuthSuccessRedirection.execute(req.query);
-      if (useCaseResult.provider === "proConnect") {
-        return res.status(302).redirect(useCaseResult.redirectUri);
+      try {
+        const result = await deps.useCases.afterOAuthSuccessRedirection.execute(
+          req.query,
+        );
+        if (result.provider === "email") {
+          return result;
+        }
+        return res.status(302).redirect(result.redirectUri);
+      } catch (error) {
+        if (error instanceof ManagedFTConnectError)
+          return res.redirect(makeRedirectErrorUrl({}, deps.config));
+        if (error instanceof FTConnectError)
+          return res.redirect(
+            makeRedirectErrorUrl(
+              { title: error.title, message: error.message },
+              deps.config,
+            ),
+          );
+
+        throw error;
       }
-      return useCaseResult;
-    });
-  });
-
-  authSharedRouter.afterFTConnectOAuthLogin(async (req, res) => {
-    return sendHttpResponse(req, res, async () => {
-      return deps.useCases.afterOAuthSuccessRedirection
-        .execute(req.query)
-        .then((result) => {
-          return res.status(302).redirect(result.redirectUri);
-        })
-        .catch((error) => {
-          if (error instanceof ManagedFTConnectError)
-            return res.redirect(makeRedirectErrorUrl({}, deps.config));
-          if (error instanceof FTConnectError)
-            return res.redirect(
-              makeRedirectErrorUrl(
-                { title: error.title, message: error.message },
-                deps.config,
-              ),
-            );
-
-          throw error;
-        });
     });
   });
 

--- a/back/src/config/bootstrap/appConfig.ts
+++ b/back/src/config/bootstrap/appConfig.ts
@@ -5,7 +5,6 @@ import {
   authRoutes,
   environments,
   filterNotFalsy,
-  ftConnect,
   loginByEmailLinkDurationInMinutes,
   makeGetBooleanVariable,
   makeThrowIfNotAbsoluteUrl,
@@ -322,7 +321,7 @@ export class AppConfig {
         this.proConnectGateway !== "HTTPS" ? "fake secret" : undefined,
       ),
       immersionRedirectUri: {
-        afterLogin: `${this.immersionFacileBaseUrl}/api${authRoutes.afterEmailOrProConnectOAuthLogin.url}`,
+        afterLogin: `${this.immersionFacileBaseUrl}/api${authRoutes.afterLogin.url}`,
         afterLogout: this.immersionFacileBaseUrl,
       },
       providerBaseUri: this.#throwIfNotAbsoluteUrl(
@@ -348,7 +347,7 @@ export class AppConfig {
           ? this.franceTravailClientSecret
           : "fake secret",
       immersionRedirectUri: {
-        afterLogin: `${this.immersionFacileBaseUrl}/api/${ftConnect}`,
+        afterLogin: `${this.immersionFacileBaseUrl}/api${authRoutes.afterLogin.url}`,
         afterLogout: this.immersionFacileBaseUrl,
       },
       providerBaseUri:

--- a/front/src/core-logic/adapters/AuthGateway/HttpAuthGateway.ts
+++ b/front/src/core-logic/adapters/AuthGateway/HttpAuthGateway.ts
@@ -103,7 +103,7 @@ export class HttpAuthGateway implements AuthGateway {
   ): Observable<AfterOAuthSuccessRedirectionResponse> {
     return from(
       this.httpClient
-        .afterEmailOrProConnectOAuthLogin({
+        .afterLogin({
           queryParams: params,
         })
         .then((response) =>

--- a/shared/src/auth/auth.routes.ts
+++ b/shared/src/auth/auth.routes.ts
@@ -4,7 +4,6 @@ import { absoluteUrlSchema } from "../AbsoluteUrl";
 import { withUserFiltersSchema } from "../admin/admin.schema";
 import { withAuthorizationHeaders } from "../headers";
 import { httpErrorSchema } from "../httpClient/httpErrors.schema";
-import { ftConnect } from "../routes/routes";
 import { renewExpiredJwtRequestSchema } from "../tokens/jwt.schema";
 import {
   connectedUserSchema,
@@ -40,22 +39,12 @@ export const authRoutes = defineRoutes({
       200: expressEmptyResponseBody,
     },
   }),
-  afterEmailOrProConnectOAuthLogin: defineRoute({
+  afterLogin: defineRoute({
     method: "get",
-    url: "/inclusion-connect-after-login", // URI déclarée chez ProConnect, ne pas toucher sauf si on change la config chez ProConnect
+    url: "/login-callback",
     queryParamsSchema: oAuthSuccessLoginParamsSchema,
     responses: {
       200: afterOAuthSuccessRedirectionResponseSchema,
-      302: emptyObjectSchema,
-      400: httpErrorSchema,
-      403: httpErrorSchema,
-    },
-  }),
-  afterFTConnectOAuthLogin: defineRoute({
-    method: "get",
-    url: `/${ftConnect}`, // URI déclarée chez FT Connect ?
-    queryParamsSchema: oAuthSuccessLoginParamsSchema,
-    responses: {
       302: emptyObjectSchema,
       400: httpErrorSchema,
       403: httpErrorSchema,


### PR DESCRIPTION
Fixes #5212

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

✅ Nouvelle url déclarée auprès de ProConnect local/staging/pentest
✅ Nouvelle url déclarée auprès de FT Connect
✅ Nouvelle url déclarée auprès de ProConnect prod

Finalement pas d'url à modifier pour la déconnexion :
- /api/logout/oauth est la route appelée pour se déconnecter, ce n'est pas une callback
- cette route va déclencher une demande de déconnexion auprès de ProConnect, avec un queryparam post_logout_redirect_uri vers la homepage IF.
