### PR TITLE
#5649 - Une structure d'accompagnement ne peut plus choisir une SIAE comme prescripteur référent

### DIFF
--- a/back/src/domains/agency/use-cases/AddAgency.ts
+++ b/back/src/domains/agency/use-cases/AddAgency.ts
@@ -7,6 +7,7 @@ import {
   createAgencySchema,
   errors,
   executeInSequence,
+  isFitForDelegationAgencyKind,
   type UserId,
 } from "shared";
 import { createOrGetUserIdByEmail } from "../../core/authentication/connected-user/entities/user.helper";
@@ -120,6 +121,10 @@ const getReferredAgencyValidatorUserIds = async (
   const referredAgency = await uow.agencyRepository.getById(refersToAgencyId);
   if (!referredAgency)
     throw errors.agency.notFound({ agencyId: refersToAgencyId });
+  if (!isFitForDelegationAgencyKind(referredAgency.kind))
+    throw errors.agency.invalidKindForReferringAgency({
+      kind: referredAgency.kind,
+    });
   return toPairs(referredAgency.usersRights)
     .filter(([_, right]) => right?.roles.includes("validator"))
     .map(([userId, right]) => ({

--- a/back/src/domains/agency/use-cases/AddAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/AddAgency.unit.test.ts
@@ -461,6 +461,37 @@ describe("AddAgency use case", () => {
       );
     });
 
+    it.each(["structure-IAE", "cci", "autre", "operateur-cep"] as const)(
+      "fails when referred agency kind is %s",
+      async (kind) => {
+        const referredAgency = new AgencyDtoBuilder()
+          .withId("referred-agency-id")
+          .withKind(kind)
+          .withName("Agence référente")
+          .withAgencySiret(TEST_OPEN_ESTABLISHMENT_1.siret)
+          .build();
+        const referredAgencyWithRights = toAgencyWithRights(referredAgency, {
+          [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+        });
+
+        uow.userRepository.users = [validator];
+        uow.agencyRepository.agencies = [referredAgencyWithRights];
+
+        await expectPromiseToFailWithError(
+          addAgency.execute({
+            ...createAgencyWithRefersToParams,
+            refersToAgencyId: referredAgency.id,
+            refersToAgencyName: referredAgency.name,
+            refersToAgencyContactEmail: referredAgency.contactEmail,
+          }),
+          errors.agency.invalidKindForReferringAgency({ kind }),
+        );
+        expectToEqual(uow.agencyRepository.agencies, [
+          referredAgencyWithRights,
+        ]);
+      },
+    );
+
     it("fails to create if agency siret is not valid", async () => {
       const newAgency = new AgencyDtoBuilder()
         .withId("agency-to-create-id")

--- a/shared/src/agency/agency.dto.ts
+++ b/shared/src/agency/agency.dto.ts
@@ -187,8 +187,11 @@ export const allAgencyKindsAllowedToAdd = keys(agencyKindToLabel).sort(
 );
 
 export const fitForDelegationAgencyKind = allAgencyKindsAllowedToAdd.filter(
-  (kind) => !["autre", "cci", "operateur-cep"].includes(kind),
+  (kind) => !["autre", "cci", "operateur-cep", "structure-IAE"].includes(kind),
 );
+
+export const isFitForDelegationAgencyKind = (kind: AgencyKind): boolean =>
+  fitForDelegationAgencyKind.some((allowedKind) => allowedKind === kind);
 
 export const delegationAgencyKindList = [
   "france-travail",

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -1,8 +1,10 @@
 import type { LocationId } from "../address/address.dto";
-import type {
-  AgencyId,
-  AgencyStatus,
-  AgencyWithUsersRights,
+import {
+  type AgencyId,
+  type AgencyKind,
+  type AgencyStatus,
+  type AgencyWithUsersRights,
+  agencyKindToLabelIncludingIFAndPrepa,
 } from "../agency/agency.dto";
 import type {
   ApiConsumerId,
@@ -934,6 +936,10 @@ export const errors = {
     }) =>
       new ForbiddenError(
         `L'agence '${agencyId}' n'est pas éligible pour ce rappel de convention de délégation.`,
+      ),
+    invalidKindForReferringAgency: ({ kind }: { kind: AgencyKind }) =>
+      new BadRequestError(
+        `Une structure de type « ${agencyKindToLabelIncludingIFAndPrepa[kind]} » ne peut pas être désignée comme prescripteur référent.`,
       ),
     invalidSiret: ({ siret }: { siret: SiretDto }) =>
       new NotFoundError(


### PR DESCRIPTION
Fixes #5649

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
