### PR TITLE
#5539 - Afficher le nom d’enseigne sur les documents de convention et de bilan

### DIFF
--- a/front/src/app/pages/convention/AssessmentDocumentPage.tsx
+++ b/front/src/app/pages/convention/AssessmentDocumentPage.tsx
@@ -264,7 +264,9 @@ export const AssessmentDocumentPage = ({
           firstname: convention.signatories.beneficiary.firstName,
           lastname: convention.signatories.beneficiary.lastName,
         })}
-        businessName={convention.businessName}
+        businessName={
+          convention.businessNameCustomized?.trim() || convention.businessName
+        }
         internshipKind={convention.internshipKind}
         showPrintButton={!isSignatureRequired}
         customActions={
@@ -308,7 +310,13 @@ export const AssessmentDocumentPage = ({
               new Date(convention.dateEnd),
             ),
           })}{" "}
-          au sein de <strong>{convention.businessName}</strong> (Siret n° :{" "}
+          au sein de{" "}
+          <strong>
+            {convention.businessNameCustomized?.trim()
+              ? `${convention.businessNameCustomized.trim()}, dont la raison sociale est ${convention.businessName}`
+              : convention.businessName}
+          </strong>{" "}
+          (Siret n°
           <a
             href={makeSiretDescriptionLink(convention.siret)}
             target="_blank"
@@ -316,7 +324,7 @@ export const AssessmentDocumentPage = ({
           >
             {convention.siret}
           </a>
-          ) à l'adresse suivante <strong>{convention.immersionAddress}</strong>.
+          ), à l'adresse <strong>{convention.immersionAddress}</strong>.
         </p>
         <ul>
           <li>

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -195,7 +195,9 @@ export const ConventionDocumentPage = ({
           firstname: beneficiary.firstName,
           lastname: beneficiary.lastName,
         })}
-        businessName={convention.businessName}
+        businessName={
+          convention.businessNameCustomized?.trim() || convention.businessName
+        }
         internshipKind={internshipKind}
         customActions={[
           <Button
@@ -299,8 +301,13 @@ export const ConventionDocumentPage = ({
                   lastname: establishmentRepresentative.lastName,
                 })}
               </strong>{" "}
-              en qualité de <strong>représentant de l'entreprise</strong>{" "}
-              {convention.businessName}
+              en qualité de{" "}
+              <strong>
+                représentant de{" "}
+                {convention.businessNameCustomized?.trim()
+                  ? `${convention.businessNameCustomized.trim()}, dont la raison sociale est ${convention.businessName}`
+                  : convention.businessName}
+              </strong>
               <ul>
                 <li>tel.&nbsp;: {establishmentRepresentative.phone}</li>
                 <li>email&nbsp;: {establishmentRepresentative.email}</li>
@@ -434,8 +441,13 @@ export const ConventionDocumentPage = ({
         <h4 className={fr.cx("fr-h6")}>Lieu et dates</h4>
         <p>
           {internshipKind === "immersion" ? "Cette immersion" : "Ce mini-stage"}{" "}
-          se déroulera au sein de <strong>{convention.businessName}</strong>,
-          (Siret n° :{" "}
+          se déroulera au sein de{" "}
+          <strong>
+            {convention.businessNameCustomized?.trim()
+              ? `${convention.businessNameCustomized.trim()}, dont la raison sociale est ${convention.businessName}`
+              : convention.businessName}
+          </strong>{" "}
+          (Siret n°
           <a
             href={makeSiretDescriptionLink(convention.siret)}
             target="_blank"
@@ -443,7 +455,7 @@ export const ConventionDocumentPage = ({
           >
             {convention.siret}
           </a>
-          ) à l'adresse suivante <strong>{convention.immersionAddress}</strong>.
+          ), à l'adresse <strong>{convention.immersionAddress}</strong>.
         </p>
         <p className={fr.cx("fr-text--bold")}>
           {internshipKind === "immersion" ? "L'immersion" : "Le mini-stage"} se


### PR DESCRIPTION
Fixes #5539
Fixes #5540

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
